### PR TITLE
Use js-lexer for js within html script tags

### DIFF
--- a/dev/accordion.html
+++ b/dev/accordion.html
@@ -9,7 +9,7 @@
 
     <script type="module">
       import '@scoped-vaadin/accordion';
-      // import '@scoped-vaadin/accordion/theme/material/vaadin-accordion.js';
+      // import '@vaadin/accordion/theme/material/vaadin-accordion.js';
     </script>
   </head>
 

--- a/dev/context-menu.html
+++ b/dev/context-menu.html
@@ -9,6 +9,7 @@
 
     <script type="module">
       import '@scoped-vaadin/context-menu';
+      // import '@vaadin/context-menu/theme/lumo/vaadin-lit-context-menu.js';
 
       const menu = document.querySelector('vaadin24-context-menu');
       menu.items = [

--- a/dev/details.html
+++ b/dev/details.html
@@ -10,8 +10,8 @@
     <script type="module">
       import '@scoped-vaadin/details';
       import '@scoped-vaadin/tooltip';
-      // import '@scoped-vaadin/details/theme/material/vaadin-details.js';
-      // import '@scoped-vaadin/tooltip/theme/material/vaadin-tooltip.js';
+      // import '@vaadin/details/theme/material/vaadin-details.js';
+      // import '@vaadin/tooltip/theme/material/vaadin-tooltip.js';
     </script>
   </head>
 

--- a/dev/field-highlighter.html
+++ b/dev/field-highlighter.html
@@ -23,8 +23,8 @@
 
     <script type="module">
       import '@scoped-vaadin/checkbox-group';
-      // import '@scoped-vaadin/date-time-picker';
-      // import '@scoped-vaadin/text-area';
+      // import '@vaadin/date-time-picker';
+      // import '@vaadin/text-area';
       import { FieldHighlighter } from '@scoped-vaadin/field-highlighter';
 
       const field = document.querySelector('vaadin24-checkbox-group');

--- a/dev/grid-performance.html
+++ b/dev/grid-performance.html
@@ -96,9 +96,18 @@
         });
       }
       refreshLoop();
+
+      // Controls
+      const lazyColumnRendering = document.querySelector('vaadin24-checkbox');
+      lazyColumnRendering.addEventListener('checked-changed', (e) => {
+        grid.columnRendering = e.detail.value ? 'lazy' : 'eager';
+      });
+      lazyColumnRendering.checked = grid.columnRendering === 'lazy';
     </script>
 
-    <vaadin24-grid item-id-path="name"></vaadin24-grid>
+    <vaadin24-grid item-id-path="name" column-rendering="lazy"></vaadin24-grid>
+
+    <vaadin24-checkbox label="Lazy column rendering" style="margin-top: 30px"></vaadin24-checkbox>
 
     <div id="render-time"></div>
 

--- a/dev/grid.html
+++ b/dev/grid.html
@@ -9,8 +9,14 @@
   </head>
   <body>
     <script type="module">
+      // PolymerElement based imports
       import '@scoped-vaadin/grid/all-imports';
       import '@scoped-vaadin/tooltip';
+
+      // LitElement based imports
+      // import '@vaadin/grid/lit-all-imports.js';
+      // import '@vaadin/tooltip/theme/lumo/vaadin-tooltip-styles.js';
+      // import '@vaadin/tooltip/src/vaadin-lit-tooltip.js';
 
       const grid = document.querySelector('vaadin24-grid');
 
@@ -37,7 +43,7 @@
     </script>
 
     <vaadin24-grid item-id-path="name">
-      <vaadin24-grid-selection-column auto-select frozen></vaadin24-grid-selection-column>
+      <vaadin24-grid-selection-column auto-select frozen drag-select></vaadin24-grid-selection-column>
       <vaadin24-grid-tree-column frozen path="name" width="200px" flex-shrink="0"></vaadin24-grid-tree-column>
       <vaadin24-grid-column path="name" width="200px" flex-shrink="0"></vaadin24-grid-column>
       <vaadin24-grid-column path="name" width="200px" flex-shrink="0"></vaadin24-grid-column>

--- a/dev/icon.html
+++ b/dev/icon.html
@@ -4,19 +4,76 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Document</title>
+    <title>Icon</title>
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@scoped-vaadin/icon';
       import '@scoped-vaadin/icons/vaadin-iconset.js';
+      import '@scoped-vaadin/vaadin-lumo-styles/font-icons.js';
       import '@scoped-vaadin/tooltip';
+      import { Iconset } from '@scoped-vaadin/icon/vaadin-iconset.js';
+
+      const template = document.createElement('template');
+      template.innerHTML = `
+        <svg xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <svg
+              id="my-icons-iconset:logo"
+              xmlns="http://www.w3.org/2000/svg"
+              width="32"
+              height="26"
+              preserveAspectRatio="xMidYMin slice"
+            >
+              <g fill="#770C56" fill-rule="evenodd">
+                <path d="M.077 12.962c0-2.496.464-4.85 1.392-7.062A17.772 17.772 0 0 1 5.48.023h3.508C5.349 3.583 3.53 7.896 3.53 12.962c0 5.065 1.819 9.378 5.457 12.939H5.479a17.772 17.772 0 0 1-4.01-5.878C.541 17.812.077 15.458.077 12.962zm31.36 0c0 2.496-.463 4.85-1.391 7.061a17.772 17.772 0 0 1-4.01 5.878h-3.508c3.638-3.56 5.457-7.874 5.457-12.94 0-5.065-1.819-9.378-5.457-12.938h3.509A17.772 17.772 0 0 1 30.046 5.9c.928 2.212 1.392 4.566 1.392 7.062zM12.954 1.721h2.32v13.191h-2.32z"/><path d="m15.273 14.871-1.504-1.487 9.434-9.328 1.503 1.487-9.433 9.328z"/>
+              </g>
+            </svg>
+          </defs>
+        </svg>
+      `;
+
+      Iconset.register('my-icons-iconset', 32, template);
     </script>
+
+    <style>
+      h6 {
+        margin-top: var(--lumo-space-m);
+      }
+    </style>
   </head>
 
   <body>
+    <h6>Vaadin iconset icon with a tooltip</h6>
     <vaadin24-icon icon="vaadin:phone">
       <vaadin24-tooltip slot="tooltip" text="Icon tooltip text"></vaadin24-tooltip>
     </vaadin24-icon>
+
+    <h6>Custom iconset icon</h6>
+    <vaadin24-icon icon="my-icons-iconset:logo"></vaadin24-icon>
+
+    <h6>Font icon (unprefixed char)</h6>
+    <vaadin24-icon font-family="lumo-icons" char="ea0e"></vaadin24-icon>
+
+    <h6>Font icon (prefixed char)</h6>
+    <vaadin24-icon font-family="lumo-icons" char="&#xea0e;"></vaadin24-icon>
+
+    <h6>SVG Standalone</h6>
+    <vaadin24-icon src="assets/code-branch.svg"></vaadin24-icon>
+
+    <h6>SVG Standalone with fill and stroke attributes</h6>
+    <vaadin24-icon src="assets/info-circle.svg"></vaadin24-icon>
+
+    <h6>SVG Sprite</h6>
+    <vaadin24-icon src="assets/solid.svg#code-branch"></vaadin24-icon>
+
+    <h6>SVG Data</h6>
+    <vaadin24-icon id="icon-data"></vaadin24-icon>
+    <script>
+      const iconData = document.querySelector('#icon-data');
+      iconData.src = `data:image/svg+xml,${encodeURIComponent(
+        `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--! Font Awesome Free 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2023 Fonticons, Inc. --><path d="M80 104a24 24 0 1 0 0-48 24 24 0 1 0 0 48zm80-24c0 32.8-19.7 61-48 73.3v87.8c18.8-10.9 40.7-17.1 64-17.1h96c35.3 0 64-28.7 64-64v-6.7C307.7 141 288 112.8 288 80c0-44.2 35.8-80 80-80s80 35.8 80 80c0 32.8-19.7 61-48 73.3V160c0 70.7-57.3 128-128 128H176c-35.3 0-64 28.7-64 64v6.7c28.3 12.3 48 40.5 48 73.3c0 44.2-35.8 80-80 80s-80-35.8-80-80c0-32.8 19.7-61 48-73.3V352 153.3C19.7 141 0 112.8 0 80C0 35.8 35.8 0 80 0s80 35.8 80 80zm232 0a24 24 0 1 0 -48 0 24 24 0 1 0 48 0zM80 456a24 24 0 1 0 0-48 24 24 0 1 0 0 48z"/></svg>`,
+      )}`;
+    </script>
   </body>
 </html>

--- a/dev/multi-select-combo-box.html
+++ b/dev/multi-select-combo-box.html
@@ -10,7 +10,7 @@
     <script type="module">
       import '@scoped-vaadin/multi-select-combo-box';
       import '@scoped-vaadin/tooltip';
-      // import '@scoped-vaadin/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box.js';
+      // import '@vaadin/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box.js';
     </script>
   </head>
   <body>
@@ -20,7 +20,8 @@
       required
       error-message="Select at least one"
       allow-custom-value
-      style="width: 300px"
+      auto-expand-horizontally
+      auto-expand-vertically
     >
       <vaadin24-tooltip slot="tooltip" text="Vaadin multi-select-combo-box tooltip text"></vaadin24-tooltip>
     </vaadin24-multi-select-combo-box>

--- a/dev/notification.html
+++ b/dev/notification.html
@@ -9,13 +9,20 @@
   </head>
 
   <body>
-    <vaadin24-notification position="middle" duration="0" theme="success"></vaadin24-notification>
+    <vaadin24-notification position="middle" duration="0" theme="primary"></vaadin24-notification>
 
     <script type="module">
+      import '@scoped-vaadin/button';
       import '@scoped-vaadin/notification';
 
       const notification = document.querySelector('vaadin24-notification');
-      notification.renderer = (root) => (root.textContent = 'Financial report generated');
+      notification.renderer = (root) => {
+        root.innerHTML = `
+          Operation completed
+          <vaadin24-button theme="primary">Undo</vaadin24-button>
+          <vaadin24-button>Close</vaadin24-button>
+        `
+      };
       notification.open();
     </script>
   </body>

--- a/dev/split-layout.html
+++ b/dev/split-layout.html
@@ -10,15 +10,49 @@
     <script type="module">
       import '@scoped-vaadin/split-layout';
 
-      document.querySelector('#first').textContent = new Array(1000).fill('a').join(' ');
-      document.querySelector('#second').textContent = new Array(1000).fill('b').join(' ');
+      document.querySelectorAll('.first').forEach(el => {el.textContent = new Array(1000).fill('a').join(' ');});
+      document.querySelectorAll('.second').forEach(el => {el.textContent = new Array(1000).fill('b').join(' ');});
     </script>
+
+    <style>
+      vaadin24-split-layout {
+        display: inline-flex;
+        margin: 0 1rem 2rem 0;
+        /* Force the natural width of both containers to be equal */
+        font-family: monospace;
+      }
+    </style>
   </head>
 
   <body>
+    <h2>Default</h2>
     <vaadin24-split-layout style="width: 400px; height: 200px">
-      <div id="first"></div>
-      <div id="second"></div>
+      <div class="first"></div>
+      <div class="second"></div>
+    </vaadin24-split-layout>
+    <vaadin24-split-layout style="width: 400px; height: 200px" orientation="vertical">
+      <div class="first"></div>
+      <div class="second"></div>
+    </vaadin24-split-layout>
+
+    <h2>Small</h2>
+    <vaadin24-split-layout style="width: 400px; height: 200px" theme="small">
+      <div class="first"></div>
+      <div class="second"></div>
+    </vaadin24-split-layout>
+    <vaadin24-split-layout style="width: 400px; height: 200px" orientation="vertical" theme="small">
+      <div class="first"></div>
+      <div class="second"></div>
+    </vaadin24-split-layout>
+
+    <h2>Minimal</h2>
+    <vaadin24-split-layout style="width: 400px; height: 200px" theme="minimal">
+      <div class="first"></div>
+      <div class="second"></div>
+    </vaadin24-split-layout>
+    <vaadin24-split-layout style="width: 400px; height: 200px" orientation="vertical" theme="minimal">
+      <div class="first"></div>
+      <div class="second"></div>
     </vaadin24-split-layout>
   </body>
 </html>

--- a/dev/tabsheet.html
+++ b/dev/tabsheet.html
@@ -13,10 +13,10 @@
       import '@scoped-vaadin/checkbox-group';
       import '@scoped-vaadin/radio-group';
 
-      // import '@scoped-vaadin/tabsheet/theme/material/vaadin-tabsheet.js';
-      // import '@scoped-vaadin/button/theme/material/vaadin-button.js';
-      // import '@scoped-vaadin/checkbox-group/theme/material/vaadin-checkbox-group.js';
-      // import '@scoped-vaadin/radio-group/theme/material/vaadin-radio-group.js';
+      // import '@vaadin/tabsheet/theme/material/vaadin-tabsheet.js';
+      // import '@vaadin/button/theme/material/vaadin-button.js';
+      // import '@vaadin/checkbox-group/theme/material/vaadin-checkbox-group.js';
+      // import '@vaadin/radio-group/theme/material/vaadin-radio-group.js';
 
       import '@scoped-vaadin/icon';
       import '@scoped-vaadin/icons/vaadin-iconset.js';

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -10,13 +10,13 @@ import { supplementalElementNames } from "./supplemental-element-names.js";
 
 const nodePackagesRoot = "node_modules/@vaadin";
 const localPackagesRoot = "packages/vaadin";
-const majorVersion = versionMeta.vaadinVersion;
+export const majorVersion = versionMeta.vaadinVersion;
 
 function escapeRegExp(text) {
   return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
 }
 
-function allElementNames() {
+export function allElementNames() {
   let accumulator = [];
   elementMeta.forEach((meta) => {
     accumulator = [...accumulator, ...meta.elementNames];
@@ -251,7 +251,7 @@ function processLocalName(content) {
  * @param {string} content : ;
  * @param {Path} filePath
  */
-function processTagNames(content, filePath) {
+export function processTagNames(content, filePath) {
   let result = content;
 
   result = processLocalName(result);
@@ -281,7 +281,7 @@ function processTagNames(content, filePath) {
  * @param {Path} filePath
  * @returns
  */
-async function processJs(content, filePath) {
+export async function processJs(content, filePath) {
   const cleanedTagNames = processTagNames(content, filePath);
 
   await init;


### PR DESCRIPTION
Changed `build-demos` to use the js lexer to rewrite js found within `<scriot>` tags.

Aside - Found a gap in the current scripting that could potentially be a problem - it looks as though tagNames within CSS rules aren't being targeted by any of the tagName rewriting.  Need to research that further