### PR TITLE
Feature/lit compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,11 @@ This repository is not mature. Ideally, versions here would align 1:1 w/ the und
 
 Below, you can find which underlying vaadin version is used
 
-| local version | vaadin version |
-| ------------- | -------------- |
-| `v23.4.1`     | `23.4.1`       |
-| `v23.0.1`     | `~23.3.8`      |
-| `v23.0.0`     | `~23.3.8`      |
-| `v0.2.0`      | `~23.3.8`      |
-| `v0.1.0`      | `^23.3.7`      |
+| local version | vaadin version                                                 |
+| ------------- | -------------------------------------------------------------- |
+| `v23.4.100`   | `23.4.1` - note: compatibilit expiriment to allow lit v2 or v3 |
+| `v23.4.1`     | `23.4.1`                                                       |
+| `v23.0.1`     | `~23.3.8`                                                      |
+| `v23.0.0`     | `~23.3.8`                                                      |
+| `v0.2.0`      | `~23.3.8`                                                      |
+| `v0.1.0`      | `^23.3.7`                                                      |

--- a/buildinfo/vaadin/accordion/package.json.patch
+++ b/buildinfo/vaadin/accordion/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/accordion",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/accordion",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -58,11 +58,11 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/details": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/details": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/accordion/package.json.patch
+++ b/buildinfo/vaadin/accordion/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/accordion",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/accordion",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -57,11 +58,11 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/details": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/details": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/accordion/web-types.json.patch
+++ b/buildinfo/vaadin/accordion/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/accordion",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/accordion",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/accordion/web-types.json.patch
+++ b/buildinfo/vaadin/accordion/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/accordion",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/accordion",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/accordion/web-types.lit.json.patch
+++ b/buildinfo/vaadin/accordion/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/accordion",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/accordion",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/accordion/web-types.lit.json.patch
+++ b/buildinfo/vaadin/accordion/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/accordion",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/accordion",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,7 +15,7 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/app-layout/package.json.patch
+++ b/buildinfo/vaadin/app-layout/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/app-layout",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/app-layout",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -59,11 +59,11 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/button": "^23.4.100",
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/app-layout/package.json.patch
+++ b/buildinfo/vaadin/app-layout/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/app-layout",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/app-layout",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -58,11 +59,11 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/button": "^23.4.1",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/app-layout/web-types.json.patch
+++ b/buildinfo/vaadin/app-layout/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/app-layout",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/app-layout",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/app-layout/web-types.json.patch
+++ b/buildinfo/vaadin/app-layout/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/app-layout",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/app-layout",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/app-layout/web-types.lit.json.patch
+++ b/buildinfo/vaadin/app-layout/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/app-layout",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/app-layout",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/app-layout/web-types.lit.json.patch
+++ b/buildinfo/vaadin/app-layout/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/app-layout",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/app-layout",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/avatar-group/package.json.patch
+++ b/buildinfo/vaadin/avatar-group/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/avatar-group",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/avatar-group",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -60,14 +61,14 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/avatar": "^23.4.1",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/item": "^23.4.1",
-+    "@scoped-vaadin/list-box": "^23.4.1",
-+    "@scoped-vaadin/overlay": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/avatar": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/list-box": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/avatar-group/package.json.patch
+++ b/buildinfo/vaadin/avatar-group/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/avatar-group",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/avatar-group",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -61,14 +61,14 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/avatar": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/list-box": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/avatar": "^23.4.100",
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/item": "^23.4.100",
++    "@scoped-vaadin/list-box": "^23.4.100",
++    "@scoped-vaadin/overlay": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/avatar-group/web-types.json.patch
+++ b/buildinfo/vaadin/avatar-group/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/avatar-group",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/avatar-group",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/avatar-group/web-types.json.patch
+++ b/buildinfo/vaadin/avatar-group/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/avatar-group",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/avatar-group",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/avatar-group/web-types.lit.json.patch
+++ b/buildinfo/vaadin/avatar-group/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/avatar-group",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/avatar-group",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/avatar-group/web-types.lit.json.patch
+++ b/buildinfo/vaadin/avatar-group/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/avatar-group",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/avatar-group",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/avatar/package.json.patch
+++ b/buildinfo/vaadin/avatar/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/avatar",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/avatar",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -61,14 +61,14 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/list-box": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/tooltip": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/item": "^23.4.100",
++    "@scoped-vaadin/list-box": "^23.4.100",
++    "@scoped-vaadin/overlay": "^23.4.100",
++    "@scoped-vaadin/tooltip": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/avatar/package.json.patch
+++ b/buildinfo/vaadin/avatar/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/avatar",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/avatar",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -60,14 +61,14 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/item": "^23.4.1",
-+    "@scoped-vaadin/list-box": "^23.4.1",
-+    "@scoped-vaadin/overlay": "^23.4.1",
-+    "@scoped-vaadin/tooltip": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/list-box": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/tooltip": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/avatar/web-types.json.patch
+++ b/buildinfo/vaadin/avatar/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/avatar",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/avatar",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/avatar/web-types.json.patch
+++ b/buildinfo/vaadin/avatar/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/avatar",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/avatar",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/avatar/web-types.lit.json.patch
+++ b/buildinfo/vaadin/avatar/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/avatar",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/avatar",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/avatar/web-types.lit.json.patch
+++ b/buildinfo/vaadin/avatar/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/avatar",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/avatar",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/button/package.json.patch
+++ b/buildinfo/vaadin/button/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/button",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/button",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -60,10 +60,10 @@ Index: package.json
 +  "dependencies": {
 +    "@open-wc/dedupe-mixin": "^1.3.0",
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/button/package.json.patch
+++ b/buildinfo/vaadin/button/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/button",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/button",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -59,10 +60,10 @@ Index: package.json
 +  "dependencies": {
 +    "@open-wc/dedupe-mixin": "^1.3.0",
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/button/web-types.json.patch
+++ b/buildinfo/vaadin/button/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/button",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/button",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/button/web-types.json.patch
+++ b/buildinfo/vaadin/button/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/button",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/button",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/button/web-types.lit.json.patch
+++ b/buildinfo/vaadin/button/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/button",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/button",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/button/web-types.lit.json.patch
+++ b/buildinfo/vaadin/button/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/button",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/button",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/checkbox-group/package.json.patch
+++ b/buildinfo/vaadin/checkbox-group/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/checkbox-group",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/checkbox-group",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -58,12 +59,12 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/checkbox": "^23.4.1",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/field-base": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/checkbox": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/checkbox-group/package.json.patch
+++ b/buildinfo/vaadin/checkbox-group/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/checkbox-group",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/checkbox-group",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -59,12 +59,12 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/checkbox": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/checkbox": "^23.4.100",
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/field-base": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/checkbox-group/web-types.json.patch
+++ b/buildinfo/vaadin/checkbox-group/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/checkbox-group",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/checkbox-group",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/checkbox-group/web-types.json.patch
+++ b/buildinfo/vaadin/checkbox-group/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/checkbox-group",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/checkbox-group",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/checkbox-group/web-types.lit.json.patch
+++ b/buildinfo/vaadin/checkbox-group/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/checkbox-group",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/checkbox-group",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/checkbox-group/web-types.lit.json.patch
+++ b/buildinfo/vaadin/checkbox-group/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/checkbox-group",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/checkbox-group",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/checkbox/package.json.patch
+++ b/buildinfo/vaadin/checkbox/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/checkbox",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/checkbox",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -57,11 +58,11 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/field-base": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/checkbox/package.json.patch
+++ b/buildinfo/vaadin/checkbox/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/checkbox",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/checkbox",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -58,11 +58,11 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/field-base": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/checkbox/web-types.json.patch
+++ b/buildinfo/vaadin/checkbox/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/checkbox",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/checkbox",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/checkbox/web-types.json.patch
+++ b/buildinfo/vaadin/checkbox/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/checkbox",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/checkbox",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/checkbox/web-types.lit.json.patch
+++ b/buildinfo/vaadin/checkbox/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/checkbox",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/checkbox",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/checkbox/web-types.lit.json.patch
+++ b/buildinfo/vaadin/checkbox/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/checkbox",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/checkbox",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/combo-box/package.json.patch
+++ b/buildinfo/vaadin/combo-box/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/combo-box",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/combo-box",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -67,15 +67,15 @@ Index: package.json
 +  "dependencies": {
 +    "@open-wc/dedupe-mixin": "^1.3.0",
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/field-base": "^23.4.100",
++    "@scoped-vaadin/input-container": "^23.4.100",
++    "@scoped-vaadin/item": "^23.4.100",
++    "@scoped-vaadin/lit-renderer": "^23.4.100",
++    "@scoped-vaadin/overlay": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/combo-box/package.json.patch
+++ b/buildinfo/vaadin/combo-box/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/combo-box",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/combo-box",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -66,15 +67,15 @@ Index: package.json
 +  "dependencies": {
 +    "@open-wc/dedupe-mixin": "^1.3.0",
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/field-base": "^23.4.1",
-+    "@scoped-vaadin/input-container": "^23.4.1",
-+    "@scoped-vaadin/item": "^23.4.1",
-+    "@scoped-vaadin/lit-renderer": "^23.4.1",
-+    "@scoped-vaadin/overlay": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/combo-box/web-types.json.patch
+++ b/buildinfo/vaadin/combo-box/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/combo-box",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/combo-box",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/combo-box/web-types.json.patch
+++ b/buildinfo/vaadin/combo-box/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/combo-box",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/combo-box",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/combo-box/web-types.lit.json.patch
+++ b/buildinfo/vaadin/combo-box/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/combo-box",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/combo-box",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/combo-box/web-types.lit.json.patch
+++ b/buildinfo/vaadin/combo-box/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/combo-box",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/combo-box",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/component-base/package.json.patch
+++ b/buildinfo/vaadin/component-base/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/component-base",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/component-base",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -45,7 +46,7 @@ Index: package.json
 -    "sinon": "^13.0.2"
 -  },
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
-+    "lit": "^2.0.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "lit": "^2.0.0 || ^3.0.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/component-base/package.json.patch
+++ b/buildinfo/vaadin/component-base/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/component-base",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/component-base",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -47,6 +47,6 @@ Index: package.json
 -  },
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +    "lit": "^2.0.0 || ^3.0.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/confirm-dialog/package.json.patch
+++ b/buildinfo/vaadin/confirm-dialog/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/confirm-dialog",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/confirm-dialog",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -60,13 +60,13 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/dialog": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/button": "^23.4.100",
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/dialog": "^23.4.100",
++    "@scoped-vaadin/overlay": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/confirm-dialog/package.json.patch
+++ b/buildinfo/vaadin/confirm-dialog/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/confirm-dialog",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/confirm-dialog",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -59,13 +60,13 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/button": "^23.4.1",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/dialog": "^23.4.1",
-+    "@scoped-vaadin/overlay": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/dialog": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/confirm-dialog/web-types.json.patch
+++ b/buildinfo/vaadin/confirm-dialog/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/confirm-dialog",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/confirm-dialog",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/confirm-dialog/web-types.json.patch
+++ b/buildinfo/vaadin/confirm-dialog/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/confirm-dialog",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/confirm-dialog",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/confirm-dialog/web-types.lit.json.patch
+++ b/buildinfo/vaadin/confirm-dialog/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/confirm-dialog",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/confirm-dialog",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/confirm-dialog/web-types.lit.json.patch
+++ b/buildinfo/vaadin/confirm-dialog/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/confirm-dialog",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/confirm-dialog",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/context-menu/package.json.patch
+++ b/buildinfo/vaadin/context-menu/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/context-menu",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/context-menu",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -64,14 +65,14 @@ Index: package.json
 +  "dependencies": {
 +    "@open-wc/dedupe-mixin": "^1.3.0",
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/item": "^23.4.1",
-+    "@scoped-vaadin/list-box": "^23.4.1",
-+    "@scoped-vaadin/lit-renderer": "^23.4.1",
-+    "@scoped-vaadin/overlay": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/list-box": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/context-menu/package.json.patch
+++ b/buildinfo/vaadin/context-menu/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/context-menu",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/context-menu",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -65,14 +65,14 @@ Index: package.json
 +  "dependencies": {
 +    "@open-wc/dedupe-mixin": "^1.3.0",
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/list-box": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/item": "^23.4.100",
++    "@scoped-vaadin/list-box": "^23.4.100",
++    "@scoped-vaadin/lit-renderer": "^23.4.100",
++    "@scoped-vaadin/overlay": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/context-menu/web-types.json.patch
+++ b/buildinfo/vaadin/context-menu/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/context-menu",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/context-menu",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/context-menu/web-types.json.patch
+++ b/buildinfo/vaadin/context-menu/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/context-menu",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/context-menu",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/context-menu/web-types.lit.json.patch
+++ b/buildinfo/vaadin/context-menu/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/context-menu",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/context-menu",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/context-menu/web-types.lit.json.patch
+++ b/buildinfo/vaadin/context-menu/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/context-menu",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/context-menu",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/custom-field/package.json.patch
+++ b/buildinfo/vaadin/custom-field/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/custom-field",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/custom-field",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -68,11 +68,11 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/field-base": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/custom-field/package.json.patch
+++ b/buildinfo/vaadin/custom-field/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/custom-field",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/custom-field",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -67,11 +68,11 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/field-base": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/custom-field/web-types.json.patch
+++ b/buildinfo/vaadin/custom-field/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/custom-field",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/custom-field",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/custom-field/web-types.json.patch
+++ b/buildinfo/vaadin/custom-field/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/custom-field",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/custom-field",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/custom-field/web-types.lit.json.patch
+++ b/buildinfo/vaadin/custom-field/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/custom-field",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/custom-field",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/custom-field/web-types.lit.json.patch
+++ b/buildinfo/vaadin/custom-field/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/custom-field",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/custom-field",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/date-picker/package.json.patch
+++ b/buildinfo/vaadin/date-picker/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/date-picker",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/date-picker",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -62,14 +63,14 @@ Index: package.json
 +  "dependencies": {
 +    "@open-wc/dedupe-mixin": "^1.3.0",
 +    "@polymer/polymer": "^3.2.0",
-+    "@scoped-vaadin/button": "^23.4.1",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/field-base": "^23.4.1",
-+    "@scoped-vaadin/input-container": "^23.4.1",
-+    "@scoped-vaadin/overlay": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/date-picker/package.json.patch
+++ b/buildinfo/vaadin/date-picker/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/date-picker",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/date-picker",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -63,14 +63,14 @@ Index: package.json
 +  "dependencies": {
 +    "@open-wc/dedupe-mixin": "^1.3.0",
 +    "@polymer/polymer": "^3.2.0",
-+    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/button": "^23.4.100",
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/field-base": "^23.4.100",
++    "@scoped-vaadin/input-container": "^23.4.100",
++    "@scoped-vaadin/overlay": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/date-picker/web-types.json.patch
+++ b/buildinfo/vaadin/date-picker/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/date-picker",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/date-picker",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/date-picker/web-types.json.patch
+++ b/buildinfo/vaadin/date-picker/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/date-picker",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/date-picker",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/date-picker/web-types.lit.json.patch
+++ b/buildinfo/vaadin/date-picker/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/date-picker",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/date-picker",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/date-picker/web-types.lit.json.patch
+++ b/buildinfo/vaadin/date-picker/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/date-picker",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/date-picker",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/date-time-picker/package.json.patch
+++ b/buildinfo/vaadin/date-time-picker/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/date-time-picker",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/date-time-picker",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -61,14 +61,14 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/custom-field": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/date-picker": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/time-picker": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/custom-field": "^23.4.100",
++    "@scoped-vaadin/date-picker": "^23.4.100",
++    "@scoped-vaadin/field-base": "^23.4.100",
++    "@scoped-vaadin/time-picker": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/date-time-picker/package.json.patch
+++ b/buildinfo/vaadin/date-time-picker/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/date-time-picker",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/date-time-picker",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -60,14 +61,14 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/custom-field": "^23.4.1",
-+    "@scoped-vaadin/date-picker": "^23.4.1",
-+    "@scoped-vaadin/field-base": "^23.4.1",
-+    "@scoped-vaadin/time-picker": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/custom-field": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/date-picker": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/time-picker": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/date-time-picker/web-types.json.patch
+++ b/buildinfo/vaadin/date-time-picker/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/date-time-picker",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/date-time-picker",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/date-time-picker/web-types.json.patch
+++ b/buildinfo/vaadin/date-time-picker/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/date-time-picker",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/date-time-picker",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/date-time-picker/web-types.lit.json.patch
+++ b/buildinfo/vaadin/date-time-picker/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/date-time-picker",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/date-time-picker",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/date-time-picker/web-types.lit.json.patch
+++ b/buildinfo/vaadin/date-time-picker/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/date-time-picker",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/date-time-picker",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/details/package.json.patch
+++ b/buildinfo/vaadin/details/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/details",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/details",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -57,11 +58,11 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/field-base": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/details/package.json.patch
+++ b/buildinfo/vaadin/details/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/details",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/details",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -58,11 +58,11 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/field-base": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/details/web-types.json.patch
+++ b/buildinfo/vaadin/details/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/details",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/details",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/details/web-types.json.patch
+++ b/buildinfo/vaadin/details/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/details",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/details",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/details/web-types.lit.json.patch
+++ b/buildinfo/vaadin/details/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/details",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/details",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/details/web-types.lit.json.patch
+++ b/buildinfo/vaadin/details/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/details",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/details",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/dialog/package.json.patch
+++ b/buildinfo/vaadin/dialog/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/dialog",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/dialog",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -64,12 +64,12 @@ Index: package.json
 +  "dependencies": {
 +    "@open-wc/dedupe-mixin": "^1.3.0",
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/lit-renderer": "^23.4.100",
++    "@scoped-vaadin/overlay": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/dialog/package.json.patch
+++ b/buildinfo/vaadin/dialog/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/dialog",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/dialog",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -63,12 +64,12 @@ Index: package.json
 +  "dependencies": {
 +    "@open-wc/dedupe-mixin": "^1.3.0",
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/lit-renderer": "^23.4.1",
-+    "@scoped-vaadin/overlay": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/dialog/web-types.json.patch
+++ b/buildinfo/vaadin/dialog/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/dialog",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/dialog",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/dialog/web-types.json.patch
+++ b/buildinfo/vaadin/dialog/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/dialog",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/dialog",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/dialog/web-types.lit.json.patch
+++ b/buildinfo/vaadin/dialog/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/dialog",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/dialog",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/dialog/web-types.lit.json.patch
+++ b/buildinfo/vaadin/dialog/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/dialog",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/dialog",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/email-field/package.json.patch
+++ b/buildinfo/vaadin/email-field/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/email-field",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/email-field",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -57,11 +58,11 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/text-field": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/text-field": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/email-field/package.json.patch
+++ b/buildinfo/vaadin/email-field/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/email-field",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/email-field",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -58,11 +58,11 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/text-field": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/text-field": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/email-field/web-types.json.patch
+++ b/buildinfo/vaadin/email-field/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/email-field",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/email-field",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/email-field/web-types.json.patch
+++ b/buildinfo/vaadin/email-field/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/email-field",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/email-field",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/email-field/web-types.lit.json.patch
+++ b/buildinfo/vaadin/email-field/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/email-field",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/email-field",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/email-field/web-types.lit.json.patch
+++ b/buildinfo/vaadin/email-field/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/email-field",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/email-field",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/field-base/package.json.patch
+++ b/buildinfo/vaadin/field-base/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/field-base",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/field-base",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -46,8 +47,8 @@ Index: package.json
 -    "sinon": "^13.0.2"
 -  },
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "lit": "^2.0.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "lit": "^2.0.0 || ^3.0.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/field-base/package.json.patch
+++ b/buildinfo/vaadin/field-base/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/field-base",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/field-base",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -47,8 +47,8 @@ Index: package.json
 -    "sinon": "^13.0.2"
 -  },
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/component-base": "^23.4.100",
 +    "lit": "^2.0.0 || ^3.0.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/field-highlighter/package.json.patch
+++ b/buildinfo/vaadin/field-highlighter/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/field-highlighter",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/field-highlighter",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -62,12 +63,12 @@ Index: package.json
 -    "sinon": "^13.0.2"
 -  },
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/overlay": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "lit": "^2.0.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "lit": "^2.0.0 || ^3.0.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/field-highlighter/package.json.patch
+++ b/buildinfo/vaadin/field-highlighter/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/field-highlighter",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/field-highlighter",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -63,12 +63,12 @@ Index: package.json
 -    "sinon": "^13.0.2"
 -  },
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/overlay": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
 +    "lit": "^2.0.0 || ^3.0.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/form-layout/package.json.patch
+++ b/buildinfo/vaadin/form-layout/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/form-layout",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/form-layout",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -59,10 +59,10 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/form-layout/package.json.patch
+++ b/buildinfo/vaadin/form-layout/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/form-layout",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/form-layout",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -58,10 +59,10 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/form-layout/web-types.json.patch
+++ b/buildinfo/vaadin/form-layout/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/form-layout",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/form-layout",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/form-layout/web-types.json.patch
+++ b/buildinfo/vaadin/form-layout/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/form-layout",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/form-layout",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/form-layout/web-types.lit.json.patch
+++ b/buildinfo/vaadin/form-layout/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/form-layout",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/form-layout",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,14 +15,14 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/form-layout/web-types.lit.json.patch
+++ b/buildinfo/vaadin/form-layout/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/form-layout",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/form-layout",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/grid/package.json.patch
+++ b/buildinfo/vaadin/grid/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/grid",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/grid",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -63,13 +64,13 @@ Index: package.json
 +  "dependencies": {
 +    "@open-wc/dedupe-mixin": "^1.3.0",
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/checkbox": "^23.4.1",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/lit-renderer": "^23.4.1",
-+    "@scoped-vaadin/text-field": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/checkbox": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/text-field": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/grid/package.json.patch
+++ b/buildinfo/vaadin/grid/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/grid",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/grid",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -64,13 +64,13 @@ Index: package.json
 +  "dependencies": {
 +    "@open-wc/dedupe-mixin": "^1.3.0",
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/checkbox": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/text-field": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/checkbox": "^23.4.100",
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/lit-renderer": "^23.4.100",
++    "@scoped-vaadin/text-field": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/grid/web-types.json.patch
+++ b/buildinfo/vaadin/grid/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/grid",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/grid",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/grid/web-types.json.patch
+++ b/buildinfo/vaadin/grid/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/grid",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/grid",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/grid/web-types.lit.json.patch
+++ b/buildinfo/vaadin/grid/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/grid",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/grid",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/grid/web-types.lit.json.patch
+++ b/buildinfo/vaadin/grid/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/grid",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/grid",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/horizontal-layout/package.json.patch
+++ b/buildinfo/vaadin/horizontal-layout/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/horizontal-layout",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/horizontal-layout",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -55,10 +56,10 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/horizontal-layout/package.json.patch
+++ b/buildinfo/vaadin/horizontal-layout/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/horizontal-layout",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/horizontal-layout",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -56,10 +56,10 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/horizontal-layout/web-types.json.patch
+++ b/buildinfo/vaadin/horizontal-layout/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/horizontal-layout",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/horizontal-layout",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/horizontal-layout/web-types.json.patch
+++ b/buildinfo/vaadin/horizontal-layout/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/horizontal-layout",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/horizontal-layout",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/horizontal-layout/web-types.lit.json.patch
+++ b/buildinfo/vaadin/horizontal-layout/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/horizontal-layout",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/horizontal-layout",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/horizontal-layout/web-types.lit.json.patch
+++ b/buildinfo/vaadin/horizontal-layout/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/horizontal-layout",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/horizontal-layout",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/icon/package.json.patch
+++ b/buildinfo/vaadin/icon/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/icon",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/icon",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -56,10 +57,10 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "lit": "^2.0.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "lit": "^2.0.0 || ^3.0.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/icon/package.json.patch
+++ b/buildinfo/vaadin/icon/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/icon",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/icon",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -57,10 +57,10 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
 +    "lit": "^2.0.0 || ^3.0.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/icon/web-types.json.patch
+++ b/buildinfo/vaadin/icon/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/icon",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/icon",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/icon/web-types.json.patch
+++ b/buildinfo/vaadin/icon/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/icon",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/icon",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/icon/web-types.lit.json.patch
+++ b/buildinfo/vaadin/icon/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/icon",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/icon",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,20 +15,20 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/icon/web-types.lit.json.patch
+++ b/buildinfo/vaadin/icon/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/icon",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/icon",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/icons/package.json.patch
+++ b/buildinfo/vaadin/icons/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/icons",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/icons",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -48,7 +48,7 @@ Index: package.json
 -    "gulp-modify": "^0.1.1"
 -  },
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
-+    "@scoped-vaadin/icon": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/icon": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/icons/package.json.patch
+++ b/buildinfo/vaadin/icons/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/icons",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/icons",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -47,7 +48,7 @@ Index: package.json
 -    "gulp-modify": "^0.1.1"
 -  },
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
-+    "@scoped-vaadin/icon": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/icon": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/input-container/package.json.patch
+++ b/buildinfo/vaadin/input-container/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/input-container",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/input-container",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -50,10 +51,10 @@ Index: package.json
 -    "sinon": "^13.0.2"
 -  },
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/input-container/package.json.patch
+++ b/buildinfo/vaadin/input-container/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/input-container",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/input-container",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -51,10 +51,10 @@ Index: package.json
 -    "sinon": "^13.0.2"
 -  },
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/integer-field/package.json.patch
+++ b/buildinfo/vaadin/integer-field/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/integer-field",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/integer-field",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -57,10 +57,10 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/number-field": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/number-field": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/integer-field/package.json.patch
+++ b/buildinfo/vaadin/integer-field/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/integer-field",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/integer-field",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -56,10 +57,10 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/number-field": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/number-field": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/integer-field/web-types.json.patch
+++ b/buildinfo/vaadin/integer-field/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/integer-field",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/integer-field",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/integer-field/web-types.json.patch
+++ b/buildinfo/vaadin/integer-field/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/integer-field",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/integer-field",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/integer-field/web-types.lit.json.patch
+++ b/buildinfo/vaadin/integer-field/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/integer-field",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/integer-field",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/integer-field/web-types.lit.json.patch
+++ b/buildinfo/vaadin/integer-field/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/integer-field",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/integer-field",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/item/package.json.patch
+++ b/buildinfo/vaadin/item/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/item",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/item",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -58,10 +59,10 @@ Index: package.json
 +  "dependencies": {
 +    "@open-wc/dedupe-mixin": "^1.3.0",
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/item/package.json.patch
+++ b/buildinfo/vaadin/item/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/item",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/item",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -59,10 +59,10 @@ Index: package.json
 +  "dependencies": {
 +    "@open-wc/dedupe-mixin": "^1.3.0",
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/item/web-types.json.patch
+++ b/buildinfo/vaadin/item/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/item",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/item",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/item/web-types.json.patch
+++ b/buildinfo/vaadin/item/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/item",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/item",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/item/web-types.lit.json.patch
+++ b/buildinfo/vaadin/item/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/item",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/item",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/item/web-types.lit.json.patch
+++ b/buildinfo/vaadin/item/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/item",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/item",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/list-box/package.json.patch
+++ b/buildinfo/vaadin/list-box/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/list-box",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/list-box",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -59,12 +59,12 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-list-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/item": "^23.4.100",
++    "@scoped-vaadin/vaadin-list-mixin": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/list-box/package.json.patch
+++ b/buildinfo/vaadin/list-box/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/list-box",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/list-box",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -58,12 +59,12 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/item": "^23.4.1",
-+    "@scoped-vaadin/vaadin-list-mixin": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-list-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/list-box/web-types.json.patch
+++ b/buildinfo/vaadin/list-box/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/list-box",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/list-box",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/list-box/web-types.json.patch
+++ b/buildinfo/vaadin/list-box/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/list-box",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/list-box",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/list-box/web-types.lit.json.patch
+++ b/buildinfo/vaadin/list-box/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/list-box",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/list-box",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/list-box/web-types.lit.json.patch
+++ b/buildinfo/vaadin/list-box/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/list-box",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/list-box",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/lit-renderer/package.json.patch
+++ b/buildinfo/vaadin/lit-renderer/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/lit-renderer",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/lit-renderer",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -47,6 +47,6 @@ Index: package.json
 -  },
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +    "lit": "^2.0.0 || ^3.0.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/lit-renderer/package.json.patch
+++ b/buildinfo/vaadin/lit-renderer/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/lit-renderer",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/lit-renderer",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -45,7 +46,7 @@ Index: package.json
 -    "sinon": "^13.0.2"
 -  },
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
-+    "lit": "^2.0.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "lit": "^2.0.0 || ^3.0.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/login/package.json.patch
+++ b/buildinfo/vaadin/login/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/login",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/login",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -62,14 +63,14 @@ Index: package.json
 +  "dependencies": {
 +    "@open-wc/dedupe-mixin": "^1.3.0",
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/button": "^23.4.1",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/overlay": "^23.4.1",
-+    "@scoped-vaadin/password-field": "^23.4.1",
-+    "@scoped-vaadin/text-field": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/password-field": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/text-field": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/login/package.json.patch
+++ b/buildinfo/vaadin/login/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/login",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/login",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -63,14 +63,14 @@ Index: package.json
 +  "dependencies": {
 +    "@open-wc/dedupe-mixin": "^1.3.0",
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/password-field": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/text-field": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/button": "^23.4.100",
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/overlay": "^23.4.100",
++    "@scoped-vaadin/password-field": "^23.4.100",
++    "@scoped-vaadin/text-field": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/login/web-types.json.patch
+++ b/buildinfo/vaadin/login/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/login",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/login",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/login/web-types.json.patch
+++ b/buildinfo/vaadin/login/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/login",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/login",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/login/web-types.lit.json.patch
+++ b/buildinfo/vaadin/login/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/login",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/login",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/login/web-types.lit.json.patch
+++ b/buildinfo/vaadin/login/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/login",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/login",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/menu-bar/package.json.patch
+++ b/buildinfo/vaadin/menu-bar/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/menu-bar",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/menu-bar",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -61,12 +62,12 @@ Index: package.json
 +  "dependencies": {
 +    "@open-wc/dedupe-mixin": "^1.3.0",
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/button": "^23.4.1",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/context-menu": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/context-menu": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/menu-bar/package.json.patch
+++ b/buildinfo/vaadin/menu-bar/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/menu-bar",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/menu-bar",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -62,12 +62,12 @@ Index: package.json
 +  "dependencies": {
 +    "@open-wc/dedupe-mixin": "^1.3.0",
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/context-menu": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/button": "^23.4.100",
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/context-menu": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/menu-bar/web-types.json.patch
+++ b/buildinfo/vaadin/menu-bar/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/menu-bar",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/menu-bar",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/menu-bar/web-types.json.patch
+++ b/buildinfo/vaadin/menu-bar/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/menu-bar",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/menu-bar",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/menu-bar/web-types.lit.json.patch
+++ b/buildinfo/vaadin/menu-bar/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/menu-bar",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/menu-bar",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/menu-bar/web-types.lit.json.patch
+++ b/buildinfo/vaadin/menu-bar/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/menu-bar",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/menu-bar",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/message-input/package.json.patch
+++ b/buildinfo/vaadin/message-input/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/message-input",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/message-input",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -59,12 +59,12 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/text-area": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/button": "^23.4.100",
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/text-area": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/message-input/package.json.patch
+++ b/buildinfo/vaadin/message-input/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/message-input",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/message-input",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -58,12 +59,12 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/button": "^23.4.1",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/text-area": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/text-area": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/message-input/web-types.json.patch
+++ b/buildinfo/vaadin/message-input/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/message-input",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/message-input",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/message-input/web-types.json.patch
+++ b/buildinfo/vaadin/message-input/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/message-input",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/message-input",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/message-input/web-types.lit.json.patch
+++ b/buildinfo/vaadin/message-input/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/message-input",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/message-input",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/message-input/web-types.lit.json.patch
+++ b/buildinfo/vaadin/message-input/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/message-input",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/message-input",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/message-list/package.json.patch
+++ b/buildinfo/vaadin/message-list/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/message-list",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/message-list",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -58,11 +58,11 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/avatar": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/avatar": "^23.4.100",
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/message-list/package.json.patch
+++ b/buildinfo/vaadin/message-list/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/message-list",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/message-list",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -57,11 +58,11 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/avatar": "^23.4.1",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/avatar": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/message-list/web-types.json.patch
+++ b/buildinfo/vaadin/message-list/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/message-list",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/message-list",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/message-list/web-types.json.patch
+++ b/buildinfo/vaadin/message-list/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/message-list",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/message-list",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/message-list/web-types.lit.json.patch
+++ b/buildinfo/vaadin/message-list/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/message-list",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/message-list",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/message-list/web-types.lit.json.patch
+++ b/buildinfo/vaadin/message-list/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/message-list",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/message-list",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/multi-select-combo-box/package.json.patch
+++ b/buildinfo/vaadin/multi-select-combo-box/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/multi-select-combo-box",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/multi-select-combo-box",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -62,14 +62,14 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/combo-box": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/combo-box": "^23.4.100",
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/field-base": "^23.4.100",
++    "@scoped-vaadin/input-container": "^23.4.100",
++    "@scoped-vaadin/lit-renderer": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/multi-select-combo-box/package.json.patch
+++ b/buildinfo/vaadin/multi-select-combo-box/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/multi-select-combo-box",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/multi-select-combo-box",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -61,14 +62,14 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/combo-box": "^23.4.1",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/field-base": "^23.4.1",
-+    "@scoped-vaadin/input-container": "^23.4.1",
-+    "@scoped-vaadin/lit-renderer": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/combo-box": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/multi-select-combo-box/web-types.json.patch
+++ b/buildinfo/vaadin/multi-select-combo-box/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/multi-select-combo-box",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/multi-select-combo-box",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/multi-select-combo-box/web-types.json.patch
+++ b/buildinfo/vaadin/multi-select-combo-box/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/multi-select-combo-box",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/multi-select-combo-box",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/multi-select-combo-box/web-types.lit.json.patch
+++ b/buildinfo/vaadin/multi-select-combo-box/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/multi-select-combo-box",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/multi-select-combo-box",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/multi-select-combo-box/web-types.lit.json.patch
+++ b/buildinfo/vaadin/multi-select-combo-box/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/multi-select-combo-box",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/multi-select-combo-box",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/notification/package.json.patch
+++ b/buildinfo/vaadin/notification/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/notification",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/notification",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -60,12 +61,12 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/lit-renderer": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "lit": "^2.0.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "lit": "^2.0.0 || ^3.0.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/notification/package.json.patch
+++ b/buildinfo/vaadin/notification/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/notification",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/notification",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -61,12 +61,12 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/lit-renderer": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
 +    "lit": "^2.0.0 || ^3.0.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/notification/web-types.json.patch
+++ b/buildinfo/vaadin/notification/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/notification",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/notification",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/notification/web-types.json.patch
+++ b/buildinfo/vaadin/notification/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/notification",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/notification",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/notification/web-types.lit.json.patch
+++ b/buildinfo/vaadin/notification/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/notification",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/notification",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/notification/web-types.lit.json.patch
+++ b/buildinfo/vaadin/notification/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/notification",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/notification",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/number-field/package.json.patch
+++ b/buildinfo/vaadin/number-field/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/number-field",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/number-field",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -59,12 +59,12 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/field-base": "^23.4.100",
++    "@scoped-vaadin/input-container": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/number-field/package.json.patch
+++ b/buildinfo/vaadin/number-field/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/number-field",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/number-field",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -58,12 +59,12 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/field-base": "^23.4.1",
-+    "@scoped-vaadin/input-container": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/number-field/web-types.json.patch
+++ b/buildinfo/vaadin/number-field/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/number-field",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/number-field",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/number-field/web-types.json.patch
+++ b/buildinfo/vaadin/number-field/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/number-field",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/number-field",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/number-field/web-types.lit.json.patch
+++ b/buildinfo/vaadin/number-field/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/number-field",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/number-field",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/number-field/web-types.lit.json.patch
+++ b/buildinfo/vaadin/number-field/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/number-field",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/number-field",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/overlay/package.json.patch
+++ b/buildinfo/vaadin/overlay/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/overlay",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/overlay",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -54,10 +54,10 @@ Index: package.json
 -    "sinon": "^13.0.2"
 -  },
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/overlay/package.json.patch
+++ b/buildinfo/vaadin/overlay/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/overlay",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/overlay",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -53,10 +54,10 @@ Index: package.json
 -    "sinon": "^13.0.2"
 -  },
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/password-field/package.json.patch
+++ b/buildinfo/vaadin/password-field/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/password-field",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/password-field",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -58,12 +59,12 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/button": "^23.4.1",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/text-field": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/text-field": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/password-field/package.json.patch
+++ b/buildinfo/vaadin/password-field/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/password-field",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/password-field",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -59,12 +59,12 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/text-field": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/button": "^23.4.100",
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/text-field": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/password-field/web-types.json.patch
+++ b/buildinfo/vaadin/password-field/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/password-field",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/password-field",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/password-field/web-types.json.patch
+++ b/buildinfo/vaadin/password-field/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/password-field",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/password-field",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/password-field/web-types.lit.json.patch
+++ b/buildinfo/vaadin/password-field/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/password-field",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/password-field",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/password-field/web-types.lit.json.patch
+++ b/buildinfo/vaadin/password-field/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/password-field",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/password-field",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/polymer-legacy-adapter/package.json.patch
+++ b/buildinfo/vaadin/polymer-legacy-adapter/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/polymer-legacy-adapter",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/polymer-legacy-adapter",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -49,8 +50,8 @@ Index: package.json
 -    "sinon": "^13.0.2"
 -  },
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "lit": "^2.0.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "lit": "^2.0.0 || ^3.0.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/polymer-legacy-adapter/package.json.patch
+++ b/buildinfo/vaadin/polymer-legacy-adapter/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/polymer-legacy-adapter",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/polymer-legacy-adapter",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -50,8 +50,8 @@ Index: package.json
 -    "sinon": "^13.0.2"
 -  },
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
 +    "lit": "^2.0.0 || ^3.0.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/progress-bar/package.json.patch
+++ b/buildinfo/vaadin/progress-bar/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/progress-bar",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/progress-bar",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -57,10 +58,10 @@ Index: package.json
 +  "dependencies": {
 +    "@open-wc/dedupe-mixin": "^1.3.0",
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/progress-bar/package.json.patch
+++ b/buildinfo/vaadin/progress-bar/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/progress-bar",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/progress-bar",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -58,10 +58,10 @@ Index: package.json
 +  "dependencies": {
 +    "@open-wc/dedupe-mixin": "^1.3.0",
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/progress-bar/web-types.json.patch
+++ b/buildinfo/vaadin/progress-bar/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/progress-bar",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/progress-bar",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/progress-bar/web-types.json.patch
+++ b/buildinfo/vaadin/progress-bar/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/progress-bar",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/progress-bar",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/progress-bar/web-types.lit.json.patch
+++ b/buildinfo/vaadin/progress-bar/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/progress-bar",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/progress-bar",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/progress-bar/web-types.lit.json.patch
+++ b/buildinfo/vaadin/progress-bar/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/progress-bar",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/progress-bar",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/radio-group/package.json.patch
+++ b/buildinfo/vaadin/radio-group/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/radio-group",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/radio-group",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -57,11 +58,11 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/field-base": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/radio-group/package.json.patch
+++ b/buildinfo/vaadin/radio-group/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/radio-group",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/radio-group",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -58,11 +58,11 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/field-base": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/radio-group/web-types.json.patch
+++ b/buildinfo/vaadin/radio-group/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/radio-group",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/radio-group",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/radio-group/web-types.json.patch
+++ b/buildinfo/vaadin/radio-group/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/radio-group",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/radio-group",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/radio-group/web-types.lit.json.patch
+++ b/buildinfo/vaadin/radio-group/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/radio-group",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/radio-group",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/radio-group/web-types.lit.json.patch
+++ b/buildinfo/vaadin/radio-group/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/radio-group",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/radio-group",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/scroller/package.json.patch
+++ b/buildinfo/vaadin/scroller/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/scroller",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/scroller",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -56,10 +56,10 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/scroller/package.json.patch
+++ b/buildinfo/vaadin/scroller/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/scroller",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/scroller",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -55,10 +56,10 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/scroller/web-types.json.patch
+++ b/buildinfo/vaadin/scroller/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/scroller",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/scroller",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/scroller/web-types.json.patch
+++ b/buildinfo/vaadin/scroller/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/scroller",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/scroller",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/scroller/web-types.lit.json.patch
+++ b/buildinfo/vaadin/scroller/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/scroller",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/scroller",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/scroller/web-types.lit.json.patch
+++ b/buildinfo/vaadin/scroller/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/scroller",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/scroller",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/select/package.json.patch
+++ b/buildinfo/vaadin/select/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/select",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/select",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -67,18 +67,18 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.2.0",
-+    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/list-box": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-list-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/button": "^23.4.100",
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/field-base": "^23.4.100",
++    "@scoped-vaadin/input-container": "^23.4.100",
++    "@scoped-vaadin/item": "^23.4.100",
++    "@scoped-vaadin/list-box": "^23.4.100",
++    "@scoped-vaadin/lit-renderer": "^23.4.100",
++    "@scoped-vaadin/overlay": "^23.4.100",
++    "@scoped-vaadin/vaadin-list-mixin": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/select/package.json.patch
+++ b/buildinfo/vaadin/select/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/select",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/select",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -66,18 +67,18 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.2.0",
-+    "@scoped-vaadin/button": "^23.4.1",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/field-base": "^23.4.1",
-+    "@scoped-vaadin/input-container": "^23.4.1",
-+    "@scoped-vaadin/item": "^23.4.1",
-+    "@scoped-vaadin/list-box": "^23.4.1",
-+    "@scoped-vaadin/lit-renderer": "^23.4.1",
-+    "@scoped-vaadin/overlay": "^23.4.1",
-+    "@scoped-vaadin/vaadin-list-mixin": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/list-box": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-list-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/select/web-types.json.patch
+++ b/buildinfo/vaadin/select/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/select",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/select",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/select/web-types.json.patch
+++ b/buildinfo/vaadin/select/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/select",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/select",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/select/web-types.lit.json.patch
+++ b/buildinfo/vaadin/select/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/select",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/select",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/select/web-types.lit.json.patch
+++ b/buildinfo/vaadin/select/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/select",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/select",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/split-layout/package.json.patch
+++ b/buildinfo/vaadin/split-layout/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/split-layout",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/split-layout",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -57,10 +57,10 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/split-layout/package.json.patch
+++ b/buildinfo/vaadin/split-layout/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/split-layout",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/split-layout",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -56,10 +57,10 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/split-layout/web-types.json.patch
+++ b/buildinfo/vaadin/split-layout/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/split-layout",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/split-layout",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/split-layout/web-types.json.patch
+++ b/buildinfo/vaadin/split-layout/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/split-layout",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/split-layout",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/split-layout/web-types.lit.json.patch
+++ b/buildinfo/vaadin/split-layout/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/split-layout",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/split-layout",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/split-layout/web-types.lit.json.patch
+++ b/buildinfo/vaadin/split-layout/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/split-layout",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/split-layout",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/tabs/package.json.patch
+++ b/buildinfo/vaadin/tabs/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/tabs",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/tabs",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -59,12 +59,12 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-list-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/item": "^23.4.100",
++    "@scoped-vaadin/vaadin-list-mixin": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/tabs/package.json.patch
+++ b/buildinfo/vaadin/tabs/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/tabs",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/tabs",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -58,12 +59,12 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/item": "^23.4.1",
-+    "@scoped-vaadin/vaadin-list-mixin": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-list-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/tabs/web-types.json.patch
+++ b/buildinfo/vaadin/tabs/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/tabs",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/tabs",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/tabs/web-types.json.patch
+++ b/buildinfo/vaadin/tabs/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/tabs",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/tabs",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/tabs/web-types.lit.json.patch
+++ b/buildinfo/vaadin/tabs/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/tabs",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/tabs",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/tabs/web-types.lit.json.patch
+++ b/buildinfo/vaadin/tabs/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/tabs",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/tabs",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/tabsheet/package.json.patch
+++ b/buildinfo/vaadin/tabsheet/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/tabsheet",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/tabsheet",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -60,13 +60,13 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/scroller": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/tabs": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/field-base": "^23.4.100",
++    "@scoped-vaadin/scroller": "^23.4.100",
++    "@scoped-vaadin/tabs": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/tabsheet/package.json.patch
+++ b/buildinfo/vaadin/tabsheet/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/tabsheet",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/tabsheet",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -59,13 +60,13 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/field-base": "^23.4.1",
-+    "@scoped-vaadin/scroller": "^23.4.1",
-+    "@scoped-vaadin/tabs": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/scroller": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/tabs": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/tabsheet/web-types.json.patch
+++ b/buildinfo/vaadin/tabsheet/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/tabsheet",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/tabsheet",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/tabsheet/web-types.json.patch
+++ b/buildinfo/vaadin/tabsheet/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/tabsheet",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/tabsheet",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/tabsheet/web-types.lit.json.patch
+++ b/buildinfo/vaadin/tabsheet/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/tabsheet",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/tabsheet",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/tabsheet/web-types.lit.json.patch
+++ b/buildinfo/vaadin/tabsheet/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/tabsheet",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/tabsheet",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/text-area/package.json.patch
+++ b/buildinfo/vaadin/text-area/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/text-area",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/text-area",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -58,12 +59,12 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/field-base": "^23.4.1",
-+    "@scoped-vaadin/input-container": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/text-area/package.json.patch
+++ b/buildinfo/vaadin/text-area/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/text-area",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/text-area",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -59,12 +59,12 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/field-base": "^23.4.100",
++    "@scoped-vaadin/input-container": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/text-area/web-types.json.patch
+++ b/buildinfo/vaadin/text-area/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/text-area",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/text-area",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/text-area/web-types.json.patch
+++ b/buildinfo/vaadin/text-area/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/text-area",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/text-area",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/text-area/web-types.lit.json.patch
+++ b/buildinfo/vaadin/text-area/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/text-area",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/text-area",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/text-area/web-types.lit.json.patch
+++ b/buildinfo/vaadin/text-area/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/text-area",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/text-area",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/text-field/package.json.patch
+++ b/buildinfo/vaadin/text-field/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/text-field",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/text-field",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -58,12 +59,12 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/field-base": "^23.4.1",
-+    "@scoped-vaadin/input-container": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/text-field/package.json.patch
+++ b/buildinfo/vaadin/text-field/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/text-field",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/text-field",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -59,12 +59,12 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/field-base": "^23.4.100",
++    "@scoped-vaadin/input-container": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/text-field/web-types.json.patch
+++ b/buildinfo/vaadin/text-field/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/text-field",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/text-field",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/text-field/web-types.json.patch
+++ b/buildinfo/vaadin/text-field/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/text-field",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/text-field",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/text-field/web-types.lit.json.patch
+++ b/buildinfo/vaadin/text-field/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/text-field",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/text-field",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/text-field/web-types.lit.json.patch
+++ b/buildinfo/vaadin/text-field/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/text-field",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/text-field",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/time-picker/package.json.patch
+++ b/buildinfo/vaadin/time-picker/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/time-picker",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/time-picker",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -59,13 +60,13 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/combo-box": "^23.4.1",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/field-base": "^23.4.1",
-+    "@scoped-vaadin/input-container": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/combo-box": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/time-picker/package.json.patch
+++ b/buildinfo/vaadin/time-picker/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/time-picker",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/time-picker",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -60,13 +60,13 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/combo-box": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/combo-box": "^23.4.100",
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/field-base": "^23.4.100",
++    "@scoped-vaadin/input-container": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/time-picker/web-types.json.patch
+++ b/buildinfo/vaadin/time-picker/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/time-picker",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/time-picker",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/time-picker/web-types.json.patch
+++ b/buildinfo/vaadin/time-picker/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/time-picker",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/time-picker",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/time-picker/web-types.lit.json.patch
+++ b/buildinfo/vaadin/time-picker/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/time-picker",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/time-picker",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/time-picker/web-types.lit.json.patch
+++ b/buildinfo/vaadin/time-picker/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/time-picker",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/time-picker",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/tooltip/package.json.patch
+++ b/buildinfo/vaadin/tooltip/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/tooltip",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/tooltip",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -57,11 +58,11 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/overlay": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/tooltip/package.json.patch
+++ b/buildinfo/vaadin/tooltip/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/tooltip",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/tooltip",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -58,11 +58,11 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/overlay": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/tooltip/web-types.json.patch
+++ b/buildinfo/vaadin/tooltip/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/tooltip",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/tooltip",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/tooltip/web-types.json.patch
+++ b/buildinfo/vaadin/tooltip/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/tooltip",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/tooltip",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/tooltip/web-types.lit.json.patch
+++ b/buildinfo/vaadin/tooltip/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/tooltip",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/tooltip",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/tooltip/web-types.lit.json.patch
+++ b/buildinfo/vaadin/tooltip/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/tooltip",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/tooltip",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/upload/package.json.patch
+++ b/buildinfo/vaadin/upload/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/upload",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/upload",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -60,12 +60,12 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/progress-bar": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/button": "^23.4.100",
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/progress-bar": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/upload/package.json.patch
+++ b/buildinfo/vaadin/upload/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/upload",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/upload",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -59,12 +60,12 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/button": "^23.4.1",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/progress-bar": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/progress-bar": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/upload/web-types.json.patch
+++ b/buildinfo/vaadin/upload/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/upload",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/upload",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/upload/web-types.json.patch
+++ b/buildinfo/vaadin/upload/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/upload",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/upload",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/upload/web-types.lit.json.patch
+++ b/buildinfo/vaadin/upload/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/upload",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/upload",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/upload/web-types.lit.json.patch
+++ b/buildinfo/vaadin/upload/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/upload",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/upload",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/vaadin-list-mixin/package.json.patch
+++ b/buildinfo/vaadin/vaadin-list-mixin/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/vaadin-list-mixin",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/vaadin-list-mixin",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -46,7 +46,7 @@ Index: package.json
 -    "sinon": "^13.0.2"
 -  },
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/vaadin-list-mixin/package.json.patch
+++ b/buildinfo/vaadin/vaadin-list-mixin/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/vaadin-list-mixin",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/vaadin-list-mixin",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -45,7 +46,7 @@ Index: package.json
 -    "sinon": "^13.0.2"
 -  },
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/vaadin-lumo-styles/package.json.patch
+++ b/buildinfo/vaadin/vaadin-lumo-styles/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/vaadin-lumo-styles",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/vaadin-lumo-styles",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -48,8 +49,8 @@ Index: package.json
 -    "gulp-svgmin": "^4.1.0"
 -  },
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
-+    "@scoped-vaadin/icon": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/icon": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/vaadin-lumo-styles/package.json.patch
+++ b/buildinfo/vaadin/vaadin-lumo-styles/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/vaadin-lumo-styles",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/vaadin-lumo-styles",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -49,8 +49,8 @@ Index: package.json
 -    "gulp-svgmin": "^4.1.0"
 -  },
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
-+    "@scoped-vaadin/icon": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/icon": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/vaadin-material-styles/package.json.patch
+++ b/buildinfo/vaadin/vaadin-material-styles/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/vaadin-material-styles",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/vaadin-material-styles",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -48,7 +48,7 @@ Index: package.json
 -    "gulp-svgmin": "^4.1.0"
 -  },
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/vaadin-material-styles/package.json.patch
+++ b/buildinfo/vaadin/vaadin-material-styles/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/vaadin-material-styles",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/vaadin-material-styles",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -47,7 +48,7 @@ Index: package.json
 -    "gulp-svgmin": "^4.1.0"
 -  },
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/vaadin-themable-mixin/package.json.patch
+++ b/buildinfo/vaadin/vaadin-themable-mixin/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/vaadin-themable-mixin",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/vaadin-themable-mixin",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -48,6 +48,6 @@ Index: package.json
 -  },
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +    "lit": "^2.0.0 || ^3.0.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/vaadin-themable-mixin/package.json.patch
+++ b/buildinfo/vaadin/vaadin-themable-mixin/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/vaadin-themable-mixin",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/vaadin-themable-mixin",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -46,7 +47,7 @@ Index: package.json
 -    "sinon": "^13.0.2"
 -  },
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
-+    "lit": "^2.0.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "lit": "^2.0.0 || ^3.0.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/vertical-layout/package.json.patch
+++ b/buildinfo/vaadin/vertical-layout/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/vertical-layout",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/vertical-layout",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -55,10 +56,10 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/vertical-layout/package.json.patch
+++ b/buildinfo/vaadin/vertical-layout/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/vertical-layout",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/vertical-layout",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -56,10 +56,10 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/vertical-layout/web-types.json.patch
+++ b/buildinfo/vaadin/vertical-layout/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/vertical-layout",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/vertical-layout",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/vertical-layout/web-types.json.patch
+++ b/buildinfo/vaadin/vertical-layout/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/vertical-layout",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/vertical-layout",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/vertical-layout/web-types.lit.json.patch
+++ b/buildinfo/vaadin/vertical-layout/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/vertical-layout",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/vertical-layout",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/vertical-layout/web-types.lit.json.patch
+++ b/buildinfo/vaadin/vertical-layout/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/vertical-layout",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/vertical-layout",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/buildinfo/vaadin/virtual-list/package.json.patch
+++ b/buildinfo/vaadin/virtual-list/package.json.patch
@@ -7,7 +7,7 @@ Index: package.json
 -  "name": "@vaadin/virtual-list",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/virtual-list",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -60,11 +60,11 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
++    "@scoped-vaadin/component-base": "^23.4.100",
++    "@scoped-vaadin/lit-renderer": "^23.4.100",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
 +  }
  }

--- a/buildinfo/vaadin/virtual-list/package.json.patch
+++ b/buildinfo/vaadin/virtual-list/package.json.patch
@@ -5,8 +5,9 @@ Index: package.json
 @@ -1,21 +1,21 @@
  {
 -  "name": "@vaadin/virtual-list",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/virtual-list",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
 +  "repository": {
 +    "type": "git",
 +    "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -59,11 +60,11 @@ Index: package.json
 -  "gitHead": "7f8c68fc31880385593d59233616b23654d9c048"
 +  "dependencies": {
 +    "@polymer/polymer": "^3.0.0",
-+    "@scoped-vaadin/component-base": "^23.4.1",
-+    "@scoped-vaadin/lit-renderer": "^23.4.1",
-+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
++    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
++    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
 +  }
  }

--- a/buildinfo/vaadin/virtual-list/web-types.json.patch
+++ b/buildinfo/vaadin/virtual-list/web-types.json.patch
@@ -6,8 +6,9 @@ Index: web-types.json
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/virtual-list",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/virtual-list",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/virtual-list/web-types.json.patch
+++ b/buildinfo/vaadin/virtual-list/web-types.json.patch
@@ -8,7 +8,7 @@ Index: web-types.json
 -  "name": "@vaadin/virtual-list",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/virtual-list",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "contributions": {
      "html": {

--- a/buildinfo/vaadin/virtual-list/web-types.lit.json.patch
+++ b/buildinfo/vaadin/virtual-list/web-types.lit.json.patch
@@ -8,7 +8,7 @@ Index: web-types.lit.json
 -  "name": "@vaadin/virtual-list",
 -  "version": "23.4.1",
 +  "name": "@scoped-vaadin/virtual-list",
-+  "version": "23.4.1-litcompat.0",
++  "version": "23.4.100",
    "description-markup": "markdown",
    "framework": "lit",
    "framework-config": {

--- a/buildinfo/vaadin/virtual-list/web-types.lit.json.patch
+++ b/buildinfo/vaadin/virtual-list/web-types.lit.json.patch
@@ -2,14 +2,16 @@ Index: web-types.lit.json
 ===================================================================
 --- web-types.lit.json
 +++ web-types.lit.json
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  {
    "$schema": "https://json.schemastore.org/web-types",
 -  "name": "@vaadin/virtual-list",
+-  "version": "23.4.1",
 +  "name": "@scoped-vaadin/virtual-list",
-   "version": "23.4.1",
++  "version": "23.4.1-litcompat.0",
    "description-markup": "markdown",
    "framework": "lit",
+   "framework-config": {
 @@ -15,8 +15,8 @@
      "html": {
        "elements": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@robrez/scoped-vaadin-web-components",
-  "version": "23.4.1",
-  "lockfileVersion": 2,
+  "version": "23.4.100",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@robrez/scoped-vaadin-web-components",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "workspaces": [
         "vendor-packages/*",
@@ -35,35 +35,13 @@
         "terser": "^5.28.1"
       }
     },
-    "node_modules/@75lb/deep-merge": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@75lb/deep-merge/-/deep-merge-1.1.1.tgz",
-      "integrity": "sha512-xvgv6pkMGBA6GwdyJbNAnDmfAIR/DfWhrj9jgWh3TY7gRm3KO46x/GPjRg6wJ0nOepwqrNxFfojebh0Df4h4Tw==",
-      "dev": true,
-      "dependencies": {
-        "lodash.assignwith": "^4.2.0",
-        "typical": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=12.17"
-      }
-    },
-    "node_modules/@75lb/deep-merge/node_modules/typical": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-7.1.1.tgz",
-      "integrity": "sha512-T+tKVNs6Wu7IWiAce5BgMd7OZfNYUndHwc5MknN+UHOudi7sGZzuHdCadllRuqJ3fPtgFtIH9+lt9qRv6lmpfA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.17"
-      }
-    },
     "node_modules/@babel/code-frame": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
-      "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.24.2",
+        "@babel/highlight": "^7.24.7",
         "picocolors": "^1.0.0"
       },
       "engines": {
@@ -71,21 +49,21 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
-      "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.5.tgz",
-      "integrity": "sha512-8lLmua6AVh/8SLJRRVD6V8p73Hir9w5mJrhE+IPpILG31KKlI9iz5zmBYKcWPS59qSfgP9RaSBQSHHE81WKuEw==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.5",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "chalk": "^2.4.2",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
@@ -481,6 +459,12 @@
         "@types/chai": "^4.2.12"
       }
     },
+    "node_modules/@hapi/bourne": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-3.0.0.tgz",
+      "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==",
+      "dev": true
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -541,9 +525,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -572,9 +556,9 @@
       "dev": true
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.0.tgz",
-      "integrity": "sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.1.tgz",
+      "integrity": "sha512-wx4aBmgeGvFmOKucFKY+8VFJSYZxs9poN3SDNQFF6lT6NrQUnHiPB2PWz2sc4ieEcAaYYzN+1uWahEeTq2aRIQ=="
     },
     "node_modules/@lit/reactive-element": {
       "version": "1.6.3",
@@ -744,12 +728,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/@open-wc/semantic-dom-diff/node_modules/ip": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
-      "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
-      "dev": true
-    },
     "node_modules/@open-wc/semantic-dom-diff/node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -855,9 +833,9 @@
       }
     },
     "node_modules/@promptbook/utils": {
-      "version": "0.50.0-10",
-      "resolved": "https://registry.npmjs.org/@promptbook/utils/-/utils-0.50.0-10.tgz",
-      "integrity": "sha512-Z94YoY/wcZb5m1QoXgmIC1rVeDguGK5bWmUTYdWCqh/LHVifRdJ1C+tBzS0h+HMOD0XzMjZhBQ/mBgTZ/QNW/g==",
+      "version": "0.70.0-1",
+      "resolved": "https://registry.npmjs.org/@promptbook/utils/-/utils-0.70.0-1.tgz",
+      "integrity": "sha512-qd2lLRRN+sE6UuNMi2tEeUUeb4zmXnxY5EMdfHVXNE+bqBDpUC7/aEfXgA3jnUXEr+xFjQ8PTFQgWvBMaKvw0g==",
       "dev": true,
       "funding": [
         {
@@ -870,9 +848,7 @@
         }
       ],
       "dependencies": {
-        "moment": "2.30.1",
-        "prettier": "2.8.1",
-        "spacetrim": "0.11.25"
+        "spacetrim": "0.11.39"
       }
     },
     "node_modules/@puppeteer/browsers": {
@@ -895,23 +871,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/debug": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -962,9 +921,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.18.0.tgz",
-      "integrity": "sha512-Tya6xypR10giZV1XzxmH5wr25VcZSncG0pZIjfePT0OVBvqNEurzValetGNarVrGiq66EBVAFn15iYX4w6FKgQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.21.2.tgz",
+      "integrity": "sha512-fSuPrt0ZO8uXeS+xP3b+yYTCBUd05MoSp2N/MFOgjhhUhMmchXlpTQrTpI8T+YAwAQuK7MafsCOxW7VrPMrJcg==",
       "cpu": [
         "arm"
       ],
@@ -975,9 +934,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.18.0.tgz",
-      "integrity": "sha512-avCea0RAP03lTsDhEyfy+hpfr85KfyTctMADqHVhLAF3MlIkq83CP8UfAHUssgXTYd+6er6PaAhx/QGv4L1EiA==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.21.2.tgz",
+      "integrity": "sha512-xGU5ZQmPlsjQS6tzTTGwMsnKUtu0WVbl0hYpTPauvbRAnmIvpInhJtgjj3mcuJpEiuUw4v1s4BimkdfDWlh7gA==",
       "cpu": [
         "arm64"
       ],
@@ -988,9 +947,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.18.0.tgz",
-      "integrity": "sha512-IWfdwU7KDSm07Ty0PuA/W2JYoZ4iTj3TUQjkVsO/6U+4I1jN5lcR71ZEvRh52sDOERdnNhhHU57UITXz5jC1/w==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.21.2.tgz",
+      "integrity": "sha512-99AhQ3/ZMxU7jw34Sq8brzXqWH/bMnf7ZVhvLk9QU2cOepbQSVTns6qoErJmSiAvU3InRqC2RRZ5ovh1KN0d0Q==",
       "cpu": [
         "arm64"
       ],
@@ -1001,9 +960,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.18.0.tgz",
-      "integrity": "sha512-n2LMsUz7Ynu7DoQrSQkBf8iNrjOGyPLrdSg802vk6XT3FtsgX6JbE8IHRvposskFm9SNxzkLYGSq9QdpLYpRNA==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.21.2.tgz",
+      "integrity": "sha512-ZbRaUvw2iN/y37x6dY50D8m2BnDbBjlnMPotDi/qITMJ4sIxNY33HArjikDyakhSv0+ybdUxhWxE6kTI4oX26w==",
       "cpu": [
         "x64"
       ],
@@ -1014,9 +973,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.18.0.tgz",
-      "integrity": "sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.21.2.tgz",
+      "integrity": "sha512-ztRJJMiE8nnU1YFcdbd9BcH6bGWG1z+jP+IPW2oDUAPxPjo9dverIOyXz76m6IPA6udEL12reYeLojzW2cYL7w==",
       "cpu": [
         "arm"
       ],
@@ -1027,9 +986,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.18.0.tgz",
-      "integrity": "sha512-l3m9ewPgjQSXrUMHg93vt0hYCGnrMOcUpTz6FLtbwljo2HluS4zTXFy2571YQbisTnfTKPZ01u/ukJdQTLGh9A==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.21.2.tgz",
+      "integrity": "sha512-flOcGHDZajGKYpLV0JNc0VFH361M7rnV1ee+NTeC/BQQ1/0pllYcFmxpagltANYt8FYf9+kL6RSk80Ziwyhr7w==",
       "cpu": [
         "arm"
       ],
@@ -1040,9 +999,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.18.0.tgz",
-      "integrity": "sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.21.2.tgz",
+      "integrity": "sha512-69CF19Kp3TdMopyteO/LJbWufOzqqXzkrv4L2sP8kfMaAQ6iwky7NoXTp7bD6/irKgknDKM0P9E/1l5XxVQAhw==",
       "cpu": [
         "arm64"
       ],
@@ -1053,9 +1012,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.18.0.tgz",
-      "integrity": "sha512-be6Yx37b24ZwxQ+wOQXXLZqpq4jTckJhtGlWGZs68TgdKXJgw54lUUoFYrg6Zs/kjzAQwEwYbp8JxZVzZLRepQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.21.2.tgz",
+      "integrity": "sha512-48pD/fJkTiHAZTnZwR0VzHrao70/4MlzJrq0ZsILjLW/Ab/1XlVUStYyGt7tdyIiVSlGZbnliqmult/QGA2O2w==",
       "cpu": [
         "arm64"
       ],
@@ -1066,9 +1025,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.18.0.tgz",
-      "integrity": "sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.21.2.tgz",
+      "integrity": "sha512-cZdyuInj0ofc7mAQpKcPR2a2iu4YM4FQfuUzCVA2u4HI95lCwzjoPtdWjdpDKyHxI0UO82bLDoOaLfpZ/wviyQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1079,9 +1038,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.18.0.tgz",
-      "integrity": "sha512-ROCM7i+m1NfdrsmvwSzoxp9HFtmKGHEqu5NNDiZWQtXLA8S5HBCkVvKAxJ8U+CVctHwV2Gb5VUaK7UAkzhDjlg==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.21.2.tgz",
+      "integrity": "sha512-RL56JMT6NwQ0lXIQmMIWr1SW28z4E4pOhRRNqwWZeXpRlykRIlEpSWdsgNWJbYBEWD84eocjSGDu/XxbYeCmwg==",
       "cpu": [
         "riscv64"
       ],
@@ -1092,9 +1051,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.18.0.tgz",
-      "integrity": "sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.21.2.tgz",
+      "integrity": "sha512-PMxkrWS9z38bCr3rWvDFVGD6sFeZJw4iQlhrup7ReGmfn7Oukrr/zweLhYX6v2/8J6Cep9IEA/SmjXjCmSbrMQ==",
       "cpu": [
         "s390x"
       ],
@@ -1105,9 +1064,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.18.0.tgz",
-      "integrity": "sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.21.2.tgz",
+      "integrity": "sha512-B90tYAUoLhU22olrafY3JQCFLnT3NglazdwkHyxNDYF/zAxJt5fJUB/yBoWFoIQ7SQj+KLe3iL4BhOMa9fzgpw==",
       "cpu": [
         "x64"
       ],
@@ -1118,9 +1077,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.18.0.tgz",
-      "integrity": "sha512-LKaqQL9osY/ir2geuLVvRRs+utWUNilzdE90TpyoX0eNqPzWjRm14oMEE+YLve4k/NAqCdPkGYDaDF5Sw+xBfg==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.21.2.tgz",
+      "integrity": "sha512-7twFizNXudESmC9oneLGIUmoHiiLppz/Xs5uJQ4ShvE6234K0VB1/aJYU3f/4g7PhssLGKBVCC37uRkkOi8wjg==",
       "cpu": [
         "x64"
       ],
@@ -1131,9 +1090,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.18.0.tgz",
-      "integrity": "sha512-7J6TkZQFGo9qBKH0pk2cEVSRhJbL6MtfWxth7Y5YmZs57Pi+4x6c2dStAUvaQkHQLnEQv1jzBUW43GvZW8OFqA==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.21.2.tgz",
+      "integrity": "sha512-9rRero0E7qTeYf6+rFh3AErTNU1VCQg2mn7CQcI44vNUWM9Ze7MSRS/9RFuSsox+vstRt97+x3sOhEey024FRQ==",
       "cpu": [
         "arm64"
       ],
@@ -1144,9 +1103,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.18.0.tgz",
-      "integrity": "sha512-Txjh+IxBPbkUB9+SXZMpv+b/vnTEtFyfWZgJ6iyCmt2tdx0OF5WhFowLmnh8ENGNpfUlUZkdI//4IEmhwPieNg==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.21.2.tgz",
+      "integrity": "sha512-5rA4vjlqgrpbFVVHX3qkrCo/fZTj1q0Xxpg+Z7yIo3J2AilW7t2+n6Q8Jrx+4MrYpAnjttTYF8rr7bP46BPzRw==",
       "cpu": [
         "ia32"
       ],
@@ -1157,9 +1116,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.18.0.tgz",
-      "integrity": "sha512-UOo5FdvOL0+eIVTgS4tIdbW+TtnBLWg1YBCcU2KWM7nuNwRz9bksDX1bekJJCpu25N1DVWaCwnT39dVQxzqS8g==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.21.2.tgz",
+      "integrity": "sha512-6UUxd0+SKomjdzuAcp+HAmxw1FlGBnl1v2yEPSabtx4lBfdXHDVsW7+lQkgz9cNFJGY3AWR7+V8P5BqkD9L9nA==",
       "cpu": [
         "x64"
       ],
@@ -1426,6 +1385,15 @@
         "type-detect": "4.0.8"
       }
     },
+    "node_modules/@sinonjs/commons/node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@sinonjs/fake-timers": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
@@ -1447,9 +1415,9 @@
       }
     },
     "node_modules/@sinonjs/text-encoding": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
-      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
       "dev": true
     },
     "node_modules/@szmarczak/http-timer": {
@@ -1508,9 +1476,9 @@
       }
     },
     "node_modules/@types/chai": {
-      "version": "4.3.16",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.16.tgz",
-      "integrity": "sha512-PatH4iOdyh3MyWtmHVFXLWCCIhUbopaltqddG9BzB+gMIzee2MJrvd+jouii9Z3wzQJruGWAm7WOMjgfG8hQlQ==",
+      "version": "4.3.19",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.19.tgz",
+      "integrity": "sha512-2hHHvQBVE2FiSK4eN0Br6snX9MtolHaTo/batnLjlGRhoQzlCL61iVpxoqO7SfFyOw+P/pwv+0zNHzKoGWz9Cw==",
       "dev": true
     },
     "node_modules/@types/co-body": {
@@ -1587,9 +1555,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.1.tgz",
-      "integrity": "sha512-ej0phymbFLoCB26dbbq5PGScsf2JAJ4IJHjG10LalgUV36XKTmA4GdA+PVllKvRk0sEKt64X8975qFnkSi0hqA==",
+      "version": "4.19.5",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.5.tgz",
+      "integrity": "sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -1696,12 +1664,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.12.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
-      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+      "version": "22.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.2.tgz",
+      "integrity": "sha512-acJsPTEqYqulZS/Yp/S3GgeE6GZ0qYODUR8aVr/DkhHQ8l9nd4j5x1/ZJy9/gHrRlFMqkO6i0I3E27Alu4jjPg==",
       "dev": true,
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/@types/parse5": {
@@ -2623,9 +2591,9 @@
       }
     },
     "node_modules/@vaadin/vaadin-usage-statistics": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.1.2.tgz",
-      "integrity": "sha512-xKs1PvRfTXsG0eWWcImLXWjv7D+f1vfoIvovppv6pZ5QX8xgcxWUdNgERlOOdGt3CTuxQXukTBW3+Qfva+OXSg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.1.3.tgz",
+      "integrity": "sha512-8r4TNknD7OJQADe3VygeofFR7UNAXZ2/jjBFP5dgI8+2uMfnuGYgbuHivasKr9WSQ64sPej6m8rDoM1uSllXjQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@vaadin/vaadin-development-mode-detector": "^2.0.0"
@@ -2662,14 +2630,14 @@
       }
     },
     "node_modules/@wdio/config": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.37.0.tgz",
-      "integrity": "sha512-1zNWhZY+z8rTQorXOZmpGE/rjE7wt2up8z0VQNupRQMhhDk5y9JgOgRRNTwLfcNv5HYRbj0LnChHh/4EGc5Nfw==",
+      "version": "8.40.3",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.40.3.tgz",
+      "integrity": "sha512-HIi+JnHEDAExhzGRQuZOXw1HWIpe/bsVFHwNISJhY6wS4Nijaigmegs2p14Rv16ydOF19hGrxdKsl8k5STIP2A==",
       "dev": true,
       "dependencies": {
-        "@wdio/logger": "8.28.0",
-        "@wdio/types": "8.37.0",
-        "@wdio/utils": "8.37.0",
+        "@wdio/logger": "8.38.0",
+        "@wdio/types": "8.40.3",
+        "@wdio/utils": "8.40.3",
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^5.0.0",
         "glob": "^10.2.2",
@@ -2680,9 +2648,9 @@
       }
     },
     "node_modules/@wdio/logger": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-8.28.0.tgz",
-      "integrity": "sha512-/s6zNCqwy1hoc+K4SJypis0Ud0dlJ+urOelJFO1x0G0rwDRWyFiUP6ijTaCcFxAm29jYEcEPWijl2xkVIHwOyA==",
+      "version": "8.38.0",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-8.38.0.tgz",
+      "integrity": "sha512-kcHL86RmNbcQP+Gq/vQUGlArfU6IIcbbnNp32rRIraitomZow+iEoc519rdQmSVusDozMS5DZthkgDdxK+vz6Q==",
       "dev": true,
       "dependencies": {
         "chalk": "^5.1.2",
@@ -2707,47 +2675,47 @@
       }
     },
     "node_modules/@wdio/protocols": {
-      "version": "8.32.0",
-      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-8.32.0.tgz",
-      "integrity": "sha512-inLJRrtIGdTz/YPbcsvpSvPlYQFTVtF3OYBwAXhG2FiP1ZwE1CQNLP/xgRGye1ymdGCypGkexRqIx3KBGm801Q==",
+      "version": "8.40.3",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-8.40.3.tgz",
+      "integrity": "sha512-wK7+eyrB3TAei8RwbdkcyoNk2dPu+mduMBOdPJjp8jf/mavd15nIUXLID1zA+w5m1Qt1DsT1NbvaeO9+aJQ33A==",
       "dev": true
     },
     "node_modules/@wdio/repl": {
-      "version": "8.24.12",
-      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-8.24.12.tgz",
-      "integrity": "sha512-321F3sWafnlw93uRTSjEBVuvWCxTkWNDs7ektQS15drrroL3TMeFOynu4rDrIz0jXD9Vas0HCD2Tq/P0uxFLdw==",
+      "version": "8.40.3",
+      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-8.40.3.tgz",
+      "integrity": "sha512-mWEiBbaC7CgxvSd2/ozpbZWebnRIc8KRu/J81Hlw/txUWio27S7IpXBlZGVvhEsNzq0+cuxB/8gDkkXvMPbesw==",
       "dev": true,
       "dependencies": {
-        "@types/node": "^20.1.0"
+        "@types/node": "^22.2.0"
       },
       "engines": {
         "node": "^16.13 || >=18"
       }
     },
     "node_modules/@wdio/types": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.37.0.tgz",
-      "integrity": "sha512-36kmSlZcVhsMlbhaSCQUfL51iG81FlbzW4Dfkz4903cDkxmh64bgxydZbRB5aPLnJzzR7tI3chIME8zSVZFR8w==",
+      "version": "8.40.3",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.40.3.tgz",
+      "integrity": "sha512-zK17uyON3Ise3m+XwiF5VrrdZcXXmvqB8AWXoKe88DiksFUPMVoCOuVL2SSX1KnA2YLlZBA55qcFZT99GORVKQ==",
       "dev": true,
       "dependencies": {
-        "@types/node": "^20.1.0"
+        "@types/node": "^22.2.0"
       },
       "engines": {
         "node": "^16.13 || >=18"
       }
     },
     "node_modules/@wdio/utils": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.37.0.tgz",
-      "integrity": "sha512-2YtT8fH8mfMuDeEXKtFgxxBBoIGezSKysKAydtV9sICg4ZJM5CSsSzhfGaszC2qgOv3WHaBsfgg0Nljp1g2Y5A==",
+      "version": "8.40.3",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.40.3.tgz",
+      "integrity": "sha512-pv/848KGfPN3YXU4QRfTYGkAu4/lejIfoGzGpvGNDcACiVxgZhyRZkJ2xVaSnGaXzF0R7pMozrkU5/DnEhcxMg==",
       "dev": true,
       "dependencies": {
         "@puppeteer/browsers": "^1.6.0",
-        "@wdio/logger": "8.28.0",
-        "@wdio/types": "8.37.0",
+        "@wdio/logger": "8.38.0",
+        "@wdio/types": "8.40.3",
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^5.1.0",
-        "edgedriver": "^5.3.5",
+        "edgedriver": "^5.5.0",
         "geckodriver": "^4.3.1",
         "get-port": "^7.0.0",
         "import-meta-resolve": "^4.0.0",
@@ -2779,6 +2747,23 @@
       },
       "engines": {
         "node": ">=16.3.0"
+      }
+    },
+    "node_modules/@wdio/utils/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wdio/utils/node_modules/lru-cache": {
@@ -2844,18 +2829,18 @@
       }
     },
     "node_modules/@web/config-loader": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@web/config-loader/-/config-loader-0.3.1.tgz",
-      "integrity": "sha512-IYjHXUgSGGNpO3YJQ9foLcazbJlAWDdJGRe9be7aOhon0Nd6Na5JIOJAej7jsMu76fKHr4b4w2LfIdNQ4fJ8pA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@web/config-loader/-/config-loader-0.3.2.tgz",
+      "integrity": "sha512-Vrjv/FexBGmAdnCYpJKLHX1dfT1UaUdvHmX1JRaWos9OvDf/tFznYJ5SpJwww3Rl87/ewvLSYG7kfsMqEAsizQ==",
       "dev": true,
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@web/dev-server": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@web/dev-server/-/dev-server-0.4.5.tgz",
-      "integrity": "sha512-R11sODOLFcm51f2uir51KE4QXRSYakDaeBeJdrUutPCmYUDEk86GjYBR3R1wslimnwGPIjhFDsXNMfASxYfgAQ==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@web/dev-server/-/dev-server-0.4.6.tgz",
+      "integrity": "sha512-jj/1bcElAy5EZet8m2CcUdzxT+CRvUjIXGh8Lt7vxtthkN9PzY9wlhWx/9WOs5iwlnG1oj0VGo6f/zvbPO0s9w==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.11",
@@ -2868,7 +2853,7 @@
         "command-line-usage": "^7.0.1",
         "debounce": "^1.2.0",
         "deepmerge": "^4.2.2",
-        "ip": "^2.0.1",
+        "internal-ip": "^6.2.0",
         "nanocolors": "^0.2.1",
         "open": "^8.0.2",
         "portfinder": "^1.0.32"
@@ -2928,9 +2913,9 @@
       }
     },
     "node_modules/@web/dev-server-rollup": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@web/dev-server-rollup/-/dev-server-rollup-0.6.3.tgz",
-      "integrity": "sha512-dzMwQRBk9Rhpfoo7vvQGvRP18sDELejJCwxsMdt509aLouIB6fviv0i87DJQWbXH24hBeq6+jSILI3JTtVaPZQ==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@web/dev-server-rollup/-/dev-server-rollup-0.6.4.tgz",
+      "integrity": "sha512-sJZfTGCCrdku5xYnQQG51odGI092hKY9YFM0X3Z0tRY3iXKXcYRaLZrErw5KfCxr6g0JRuhe4BBhqXTA5Q2I3Q==",
       "dev": true,
       "dependencies": {
         "@rollup/plugin-node-resolve": "^15.0.1",
@@ -2938,7 +2923,7 @@
         "nanocolors": "^0.2.1",
         "parse5": "^6.0.1",
         "rollup": "^4.4.0",
-        "whatwg-url": "^11.0.0"
+        "whatwg-url": "^14.0.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -2975,9 +2960,9 @@
       }
     },
     "node_modules/@web/test-runner": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/@web/test-runner/-/test-runner-0.18.2.tgz",
-      "integrity": "sha512-jA+957ic31aG/f1mr1b+HYzf/uTu4QsvFhyVgTKi2s5YQYGBbtfzx9PnYi47MVC9K9OHRbW8cq2Urds9qwSU3w==",
+      "version": "0.18.3",
+      "resolved": "https://registry.npmjs.org/@web/test-runner/-/test-runner-0.18.3.tgz",
+      "integrity": "sha512-QkVK8Qguw3Zhyu8SYR7F4VdcjyXBeJNr8W8L++s4zO/Ok7DR/Wu7+rLswn3H7OH3xYoCHRmwteehcFejefz6ew==",
       "dev": true,
       "dependencies": {
         "@web/browser-logs": "^0.4.0",
@@ -3114,13 +3099,13 @@
       }
     },
     "node_modules/@web/test-runner-saucelabs": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-saucelabs/-/test-runner-saucelabs-0.11.1.tgz",
-      "integrity": "sha512-iA6DgkAT0ed15CtLqjYoGusOJiRvmjGbz4oorv+YvYRzwjCqxrf2H19PNxEf96fj2JMEgN6TApFrvcZGBBajiw==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-saucelabs/-/test-runner-saucelabs-0.11.2.tgz",
+      "integrity": "sha512-a78JXffb/XVudaSVsPSQIsKgMN+teQZJnT+LdKg3GJoo6iWGnybNhVKF0uEs7IG4unWx5jxSmFEc8FTkQ5TtlQ==",
       "dev": true,
       "dependencies": {
         "@web/test-runner-webdriver": "^0.8.0",
-        "ip": "^2.0.1",
+        "internal-ip": "^6.2.0",
         "nanoid": "^3.1.25",
         "saucelabs": "^7.2.0",
         "webdriver": "^8.8.6",
@@ -3167,6 +3152,17 @@
       "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.11.2.tgz",
       "integrity": "sha512-vRq+GniJAYSBmTRnhCYPAPq6THYqovJ/gzGThWbgEZUQaBccndGTi1hdiUP15HzEco0I6t4RCtXyX0rsSmwgPw=="
     },
+    "node_modules/@zip.js/zip.js": {
+      "version": "2.7.52",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.52.tgz",
+      "integrity": "sha512-+5g7FQswvrCHwYKNMd/KFxZSObctLSsQOgqBSi0LzwHo3li9Eh1w5cF5ndjQw9Zbr3ajVnd2+XyiX85gAetx1Q==",
+      "dev": true,
+      "engines": {
+        "bun": ">=0.7.0",
+        "deno": ">=1.0.0",
+        "node": ">=16.5.0"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -3193,9 +3189,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -3523,28 +3519,28 @@
       "dev": true
     },
     "node_modules/bare-events": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.2.2.tgz",
-      "integrity": "sha512-h7z00dWdG0PYOQEvChhOSWvOfkIKsdZGkWr083FgN/HyoQuebSew/cgirYqh9SCuy/hRvxc5Vy6Fw8xAmYHLkQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.4.2.tgz",
+      "integrity": "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q==",
       "dev": true,
       "optional": true
     },
     "node_modules/bare-fs": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.0.tgz",
-      "integrity": "sha512-TNFqa1B4N99pds2a5NYHR15o0ZpdNKbAeKTE/+G6ED/UeOavv8RY3dr/Fu99HW3zU3pXpo2kDNO8Sjsm2esfOw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.3.tgz",
+      "integrity": "sha512-7RYKL+vZVCyAsMLi5SPu7QGauGGT8avnP/HO571ndEuV4MYdGXvLhtW67FuLPeEI8EiIY7zbbRR9x7x7HU0kgw==",
       "dev": true,
       "optional": true,
       "dependencies": {
         "bare-events": "^2.0.0",
         "bare-path": "^2.0.0",
-        "bare-stream": "^1.0.0"
+        "bare-stream": "^2.0.0"
       }
     },
     "node_modules/bare-os": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.3.0.tgz",
-      "integrity": "sha512-oPb8oMM1xZbhRQBngTgpcQ5gXw6kjOaRsSWsIeNyRxGed2w/ARyP7ScBYpWR1qfX2E5rS3gBw6OWcSQo+s+kUg==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.2.tgz",
+      "integrity": "sha512-HZoJwzC+rZ9lqEemTMiO0luOePoGYNBgsLLgegKR/cljiJvcDNhDZQkzC+NC5Oh0aHbdBNSOHpghwMuB5tqhjg==",
       "dev": true,
       "optional": true
     },
@@ -3559,13 +3555,14 @@
       }
     },
     "node_modules/bare-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-1.0.0.tgz",
-      "integrity": "sha512-KhNUoDL40iP4gFaLSsoGE479t0jHijfYdIcxRn/XtezA2BaUD0NRf/JGRpsMq6dMNM+SrCrB0YSSo/5wBY4rOQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.2.1.tgz",
+      "integrity": "sha512-YTB47kHwBW9zSG8LD77MIBAAQXjU2WjAkMHeeb7hUplVs6+IoM5I7uEVQNPMB7lj9r8I76UMdoMkGnCodHOLqg==",
       "dev": true,
       "optional": true,
       "dependencies": {
-        "streamx": "^2.16.1"
+        "b4a": "^1.6.6",
+        "streamx": "^2.18.0"
       }
     },
     "node_modules/base64-js": {
@@ -3597,15 +3594,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3627,12 +3615,6 @@
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
       }
-    },
-    "node_modules/bluebird": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
-      "dev": true
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
@@ -3845,9 +3827,9 @@
       }
     },
     "node_modules/chai": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
-      "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -3857,7 +3839,7 @@
         "get-func-name": "^2.0.2",
         "loupe": "^2.3.6",
         "pathval": "^1.1.1",
-        "type-detect": "^4.0.8"
+        "type-detect": "^4.1.0"
       },
       "engines": {
         "node": ">=4"
@@ -4233,15 +4215,19 @@
       }
     },
     "node_modules/co-body": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/co-body/-/co-body-6.1.0.tgz",
-      "integrity": "sha512-m7pOT6CdLN7FuXUcpuz/8lfQ/L77x8SchHCF4G0RBTJO20Wzmhn5Sp4/5WsKy8OSpifBSUrmg83qEqaDHdyFuQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/co-body/-/co-body-6.2.0.tgz",
+      "integrity": "sha512-Kbpv2Yd1NdL1V/V4cwLVxraHDV6K8ayohr2rmH0J87Er8+zJjcTa6dAn9QMPC9CRgU8+aNajKbSf1TzDB1yKPA==",
       "dev": true,
       "dependencies": {
+        "@hapi/bourne": "^3.0.0",
         "inflation": "^2.0.0",
         "qs": "^6.5.2",
         "raw-body": "^2.3.3",
         "type-is": "^1.6.16"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/color-convert": {
@@ -4287,14 +4273,14 @@
       }
     },
     "node_modules/command-line-usage": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.1.tgz",
-      "integrity": "sha512-NCyznE//MuTjwi3y84QVUGEOT+P5oto1e1Pk/jFPVdPPfsG03qpTIl3yw6etR+v73d0lXsoojRpvbru2sqePxQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.3.tgz",
+      "integrity": "sha512-PqMLy5+YGwhMh1wS04mVG44oqDsgyLRSKJBdOo1bnYhMKBW65gZF1dRp2OZRhiTjgUHljy99qkO7bsctLaw35Q==",
       "dev": true,
       "dependencies": {
         "array-back": "^6.2.2",
         "chalk-template": "^0.4.0",
-        "table-layout": "^3.0.0",
+        "table-layout": "^4.1.0",
         "typical": "^7.1.1"
       },
       "engines": {
@@ -4436,12 +4422,6 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
     },
     "node_modules/constant-case": {
       "version": "3.0.4",
@@ -4667,9 +4647,9 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -4732,9 +4712,9 @@
       }
     },
     "node_modules/deep-eql": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -4942,15 +4922,6 @@
         "url": "https://dotenvx.com"
       }
     },
-    "node_modules/duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "^2.0.2"
-      }
-    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -4974,17 +4945,18 @@
       }
     },
     "node_modules/edgedriver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-5.5.0.tgz",
-      "integrity": "sha512-qQIjDQ62cbDcoZ8AcN6PxQekOwGDZcTkdZj5qr6Ew1i4mMi3R0d1Y6DKlyUnkBs5GXUYua5wKB0XHMLj6FAChQ==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-5.6.1.tgz",
+      "integrity": "sha512-3Ve9cd5ziLByUdigw6zovVeWJjVs8QHVmqOB0sJ0WNeVPcwf4p18GnxMmVvlFmYRloUwf5suNuorea4QzwBIOA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@wdio/logger": "^8.28.0",
+        "@wdio/logger": "^8.38.0",
+        "@zip.js/zip.js": "^2.7.48",
         "decamelize": "^6.0.0",
         "edge-paths": "^3.0.5",
+        "fast-xml-parser": "^4.4.1",
         "node-fetch": "^3.3.2",
-        "unzipper": "^0.11.6",
         "which": "^4.0.0"
       },
       "bin": {
@@ -5085,9 +5057,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.3.tgz",
-      "integrity": "sha512-i1gCgmR9dCl6Vil6UKPI/trA69s08g/syhiDK9TG0Nf1RJjjFI+AzoWW7sPufzkgYAn861skuCwJa0pIIHYxvg==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
+      "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
       "dev": true
     },
     "node_modules/esbuild": {
@@ -5129,9 +5101,9 @@
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -5339,6 +5311,28 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.0.tgz",
+      "integrity": "sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -5429,9 +5423,9 @@
       "dev": true
     },
     "node_modules/foreground-child": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
       "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
@@ -5508,16 +5502,10 @@
         "node": ">=14.14"
       }
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
-    },
     "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -5526,88 +5514,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/fstream": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-      "deprecated": "This package is no longer supported.",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      },
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/fstream/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/fstream/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/fstream/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/fstream/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/fstream/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
       }
     },
     "node_modules/function-bind": {
@@ -5620,19 +5526,19 @@
       }
     },
     "node_modules/geckodriver": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-4.4.0.tgz",
-      "integrity": "sha512-Y/Np2VkAhBkJoFAIY3pKH3rICUcR5rH9VD6EHwh0CqUIh6Opzr/NFwfcQenYfbRT/659R15/35LpA1s6h9wPPg==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-4.4.4.tgz",
+      "integrity": "sha512-0zaw19tcmWeluqx7+Y559JGBtidu1D0Lb8ElYKiNEQu8r3sCfrLUf5V10xypl8u29ZLbgRV7WflxCJVTCkCMFA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@wdio/logger": "^8.28.0",
+        "@wdio/logger": "^9.0.0",
+        "@zip.js/zip.js": "^2.7.48",
         "decamelize": "^6.0.0",
         "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.4",
+        "https-proxy-agent": "^7.0.5",
         "node-fetch": "^3.3.2",
         "tar-fs": "^3.0.6",
-        "unzipper": "^0.11.4",
         "which": "^4.0.0"
       },
       "bin": {
@@ -5640,6 +5546,33 @@
       },
       "engines": {
         "node": "^16.13 || >=18 || >=20"
+      }
+    },
+    "node_modules/geckodriver/node_modules/@wdio/logger": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.0.4.tgz",
+      "integrity": "sha512-b6gcu0PTVb3fgK4kyAH/k5UUWN5FOUdAfhA4PAY/IZvxZTMFYMqnrZb0WRWWWqL6nu9pcrOVtCOdPBvj0cb+Nw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^5.1.2",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/geckodriver/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "dev": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/geckodriver/node_modules/isexe": {
@@ -5735,9 +5668,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.7.5",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.5.tgz",
-      "integrity": "sha512-ZCuZCnlqNzjb4QprAzXKdpp/gh6KTxSJuw3IBsPnV/7fV4NxC9ckB+vPTt8w7fJA0TaSD7c55BR47JD6MEDyDw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.8.0.tgz",
+      "integrity": "sha512-Pgba6TExTZ0FJAn1qkJAjIeKoDJ3CsI2ChuLohJnZl/tTU8MVrq3b+2t5UOPfRa4RMsorClBjJALkJUMjG1PAw==",
       "dev": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -6052,9 +5985,9 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
       "dev": true,
       "dependencies": {
         "agent-base": "^7.0.2",
@@ -6106,13 +6039,19 @@
       ]
     },
     "node_modules/ignore": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true
     },
     "node_modules/import-meta-resolve": {
       "version": "4.1.0",
@@ -6131,17 +6070,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
       }
     },
     "node_modules/inherits": {
@@ -6169,9 +6097,9 @@
       }
     },
     "node_modules/ip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
+      "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
       "dev": true
     },
     "node_modules/ip-address": {
@@ -6233,12 +6161,15 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
       "dev": true,
       "dependencies": {
-        "hasown": "^2.0.0"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6449,15 +6380,12 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.1.2.tgz",
-      "integrity": "sha512-kWmLKn2tRtfYMF/BakihVVRzBKOxz4gJMiL2Rj91WnAB5TPZumSH99R/Yf1qE1u4uRimvCSJfm6hnxohXeEXjQ==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -6494,6 +6422,18 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
       }
     },
     "node_modules/just-extend": {
@@ -6645,6 +6585,15 @@
         "node": ">= 0.6.3"
       }
     },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lighthouse-logger": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.4.2.tgz",
@@ -6671,9 +6620,9 @@
       "dev": true
     },
     "node_modules/lightningcss": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.25.0.tgz",
-      "integrity": "sha512-B08o6QQikGaY4rPuQohtFVE+X2++mm/QemwAJ/1sgnMgTwwUnafJbTmSSBWC8Tv4JPfhelXZB6sWA0Y/6eYJmQ==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.26.0.tgz",
+      "integrity": "sha512-a/XZ5hdgifrofQJUArr5AiJjx26SwMam3SJUSMjgebZbESZ96i+6Qsl8tLi0kaUsdMzBWXh9sN1Oe6hp2/dkQw==",
       "dev": true,
       "dependencies": {
         "detect-libc": "^1.0.3"
@@ -6686,21 +6635,22 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.25.0",
-        "lightningcss-darwin-x64": "1.25.0",
-        "lightningcss-freebsd-x64": "1.25.0",
-        "lightningcss-linux-arm-gnueabihf": "1.25.0",
-        "lightningcss-linux-arm64-gnu": "1.25.0",
-        "lightningcss-linux-arm64-musl": "1.25.0",
-        "lightningcss-linux-x64-gnu": "1.25.0",
-        "lightningcss-linux-x64-musl": "1.25.0",
-        "lightningcss-win32-x64-msvc": "1.25.0"
+        "lightningcss-darwin-arm64": "1.26.0",
+        "lightningcss-darwin-x64": "1.26.0",
+        "lightningcss-freebsd-x64": "1.26.0",
+        "lightningcss-linux-arm-gnueabihf": "1.26.0",
+        "lightningcss-linux-arm64-gnu": "1.26.0",
+        "lightningcss-linux-arm64-musl": "1.26.0",
+        "lightningcss-linux-x64-gnu": "1.26.0",
+        "lightningcss-linux-x64-musl": "1.26.0",
+        "lightningcss-win32-arm64-msvc": "1.26.0",
+        "lightningcss-win32-x64-msvc": "1.26.0"
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.25.0.tgz",
-      "integrity": "sha512-neCU5PrQUAec/b2mpXv13rrBWObQVaG/y0yhGKzAqN9cj7lOv13Wegnpiro0M66XAxx/cIkZfmJstRfriOR2SQ==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.26.0.tgz",
+      "integrity": "sha512-n4TIvHO1NY1ondKFYpL2ZX0bcC2y6yjXMD6JfyizgR8BCFNEeArINDzEaeqlfX9bXz73Bpz/Ow0nu+1qiDrBKg==",
       "cpu": [
         "arm64"
       ],
@@ -6718,9 +6668,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.25.0.tgz",
-      "integrity": "sha512-h1XBxDHdED7TY4/1V30UNjiqXceGbcL8ARhUfbf8CWAEhD7wMKK/4UqMHi94RDl31ko4LTmt9fS2u1uyeWYE6g==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.26.0.tgz",
+      "integrity": "sha512-Rf9HuHIDi1R6/zgBkJh25SiJHF+dm9axUZW/0UoYCW1/8HV0gMI0blARhH4z+REmWiU1yYT/KyNF3h7tHyRXUg==",
       "cpu": [
         "x64"
       ],
@@ -6738,9 +6688,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.25.0.tgz",
-      "integrity": "sha512-f7v6QwrqCFtQOG1Y7iZ4P1/EAmMsyUyRBrYbSmDxihMzdsL7xyTM753H2138/oCpam+maw2RZrXe/NA1r/I5cQ==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.26.0.tgz",
+      "integrity": "sha512-C/io7POAxp6sZxFSVGezjajMlCKQ8KSwISLLGRq8xLQpQMokYrUoqYEwmIX8mLmF6C/CZPk0gFmRSzd8biWM0g==",
       "cpu": [
         "x64"
       ],
@@ -6758,9 +6708,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.25.0.tgz",
-      "integrity": "sha512-7KSVcjci9apHxUKNjiLKXn8hVQJqCtwFg5YNvTeKi/BM91A9lQTuO57RpmpPbRIb20Qm8vR7fZtL1iL5Yo3j9A==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.26.0.tgz",
+      "integrity": "sha512-Aag9kqXqkyPSW+dXMgyWk66C984Nay2pY8Nws+67gHlDzV3cWh7TvFlzuaTaVFMVqdDTzN484LSK3u39zFBnzg==",
       "cpu": [
         "arm"
       ],
@@ -6778,9 +6728,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.25.0.tgz",
-      "integrity": "sha512-1+6tuAsUyMVG5N2rzgwaOOf84yEU+Gjl71b+wLcz26lyM/ohgFgeqPWeB/Dor0wyUnq7vg184l8goGT26cRxoQ==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.26.0.tgz",
+      "integrity": "sha512-iJmZM7fUyVjH+POtdiCtExG+67TtPUTer7K/5A8DIfmPfrmeGvzfRyBltGhQz13Wi15K1lf2cPYoRaRh6vcwNA==",
       "cpu": [
         "arm64"
       ],
@@ -6798,9 +6748,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.25.0.tgz",
-      "integrity": "sha512-4kw3ZnGQzxD8KkaB4doqfi32hP5h3o04OlrdfZ7T9VLTbUxeh3YZUKcJmhINV2rdMOOmVODqaRw1kuvvF16Q+Q==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.26.0.tgz",
+      "integrity": "sha512-XxoEL++tTkyuvu+wq/QS8bwyTXZv2y5XYCMcWL45b8XwkiS8eEEEej9BkMGSRwxa5J4K+LDeIhLrS23CpQyfig==",
       "cpu": [
         "arm64"
       ],
@@ -6818,9 +6768,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.25.0.tgz",
-      "integrity": "sha512-oVEP5rBrFQB5V7fRIPYkDxKLmd2fAbz9VagKWIRu1TlYDUFWXK4F3KztAtAKuD7tLMBSGGi1LMUueFzVe+cZbw==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.26.0.tgz",
+      "integrity": "sha512-1dkTfZQAYLj8MUSkd6L/+TWTG8V6Kfrzfa0T1fSlXCXQHrt1HC1/UepXHtKHDt/9yFwyoeayivxXAsApVxn6zA==",
       "cpu": [
         "x64"
       ],
@@ -6838,9 +6788,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.25.0.tgz",
-      "integrity": "sha512-7ssY6HwCvmPDohqtXuZG2Mh9q32LbVBhiF/SS/VMj2jUcXcsBilUEviq/zFDzhZMxl5f1lXi5/+mCuSGrMir1A==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.26.0.tgz",
+      "integrity": "sha512-yX3Rk9m00JGCUzuUhFEojY+jf/6zHs3XU8S8Vk+FRbnr4St7cjyMXdNjuA2LjiT8e7j8xHRCH8hyZ4H/btRE4A==",
       "cpu": [
         "x64"
       ],
@@ -6857,10 +6807,30 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.26.0.tgz",
+      "integrity": "sha512-X/597/cFnCogy9VItj/+7Tgu5VLbAtDF7KZDPdSw0MaL6FL940th1y3HiOzFIlziVvAtbo0RB3NAae1Oofr+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.25.0.tgz",
-      "integrity": "sha512-DUVxj1S6dCQkixQ5qiHcYojamxE02bgmSpc4p6lejPwW7WRd/pvDPDAr+BvZWAkX5MRphxB7ei6+93+42ZtvmQ==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.26.0.tgz",
+      "integrity": "sha512-pYS3EyGP3JRhfqEFYmfFDiZ9/pVNfy8jVIYtrx9TVNusVyDK3gpW1w/rbvroQ4bDJi7grdUtyrYU6V2xkY/bBw==",
       "cpu": [
         "x64"
       ],
@@ -6906,9 +6876,9 @@
       }
     },
     "node_modules/locate-app": {
-      "version": "2.4.15",
-      "resolved": "https://registry.npmjs.org/locate-app/-/locate-app-2.4.15.tgz",
-      "integrity": "sha512-oAGHATXPUHSQ74Om+3dXBRNYtCzU7Wzuhlj/WIZchqHb/5/TGJRzLEtHipMDOak0UZG9U365RMXyBzgV/fhOww==",
+      "version": "2.4.38",
+      "resolved": "https://registry.npmjs.org/locate-app/-/locate-app-2.4.38.tgz",
+      "integrity": "sha512-fJNTsDQZSiy+bn98RicvVX8e7HwH3YqZnRRisircGDGPpf0eZ2x57Ev7LGs0pCBO7hzjINVtVr5QFfK8KH7hjg==",
       "dev": true,
       "funding": [
         {
@@ -6921,7 +6891,7 @@
         }
       ],
       "dependencies": {
-        "@promptbook/utils": "0.50.0-10",
+        "@promptbook/utils": "0.70.0-1",
         "type-fest": "2.13.0",
         "userhome": "1.0.0"
       }
@@ -6942,12 +6912,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
-    },
-    "node_modules/lodash.assignwith": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz",
-      "integrity": "sha512-ZznplvbvtjK2gMvnQ1BR/zqPFZmS6jbK4p+6Up4xcRYA7yMIwxHCfbTcrYxXKzzqLsQ05eJPVznEW3tuwV7k1g==",
       "dev": true
     },
     "node_modules/lodash.camelcase": {
@@ -7182,9 +7146,9 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
         "braces": "^3.0.3",
@@ -7296,15 +7260,6 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
     },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -7382,6 +7337,15 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/nise/node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/no-case": {
@@ -7474,10 +7438,13 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
       "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -7587,9 +7554,9 @@
       }
     },
     "node_modules/pac-proxy-agent": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.1.tgz",
-      "integrity": "sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-BFi3vZnO9X5Qt6NRz7ZOaPja3ic0PhlsmCRYLOpN11+mWBCR6XJDqW5RF3j8jm4WGGQZtBA+bTfxYzeKW73eHg==",
       "dev": true,
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
@@ -7597,9 +7564,9 @@
         "debug": "^4.3.4",
         "get-uri": "^6.0.1",
         "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.2",
-        "pac-resolver": "^7.0.0",
-        "socks-proxy-agent": "^8.0.2"
+        "https-proxy-agent": "^7.0.5",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.4"
       },
       "engines": {
         "node": ">= 14"
@@ -7622,6 +7589,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
       "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+      "dev": true
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "dev": true
     },
     "node_modules/param-case": {
@@ -7747,9 +7720,9 @@
       "dev": true
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
+      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
       "dev": true
     },
     "node_modules/picomatch": {
@@ -7786,33 +7759,47 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.44.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.1.tgz",
-      "integrity": "sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==",
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.46.1.tgz",
+      "integrity": "sha512-oPcr1yqoXLCkgKtD5eNUPLiN40rYEM39odNpIb6VE6S7/15gJmA1NzVv6zJYusV0e7tzvkU/utBFNa/Kpxmwng==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.44.1"
+        "playwright-core": "1.46.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.44.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.1.tgz",
-      "integrity": "sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==",
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.46.1.tgz",
+      "integrity": "sha512-h9LqIQaAv+CYvWzsZ+h3RsrqCStkBHlgo6/TJlFst3cOTlLghBQlJwPOZKQJTKNaD3QIB7aAVQ+gfWbN3NXB7A==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pngjs": {
@@ -7857,21 +7844,6 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
-      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/process": {
@@ -7967,23 +7939,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/puppeteer-core/node_modules/debug": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/puppeteer-core/node_modules/ws": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
@@ -8006,9 +7961,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
-      "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "dev": true,
       "dependencies": {
         "side-channel": "^1.0.6"
@@ -8347,9 +8302,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.18.0.tgz",
-      "integrity": "sha512-QmJz14PX3rzbJCN1SG4Xe/bAAX2a6NpCP8ab2vfu2GiUr8AQcr2nCV/oEO3yneFarB67zk8ShlIyWb2LGTb3Sg==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.21.2.tgz",
+      "integrity": "sha512-e3TapAgYf9xjdLvKQCkQTnbTKd4a6jwlpQSJJFokHGaX2IVjoEqkIIhiQfqsi0cdwlOD+tQGuOd5AJkc5RngBw==",
       "dev": true,
       "dependencies": {
         "@types/estree": "1.0.5"
@@ -8362,22 +8317,22 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.18.0",
-        "@rollup/rollup-android-arm64": "4.18.0",
-        "@rollup/rollup-darwin-arm64": "4.18.0",
-        "@rollup/rollup-darwin-x64": "4.18.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.18.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.18.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.18.0",
-        "@rollup/rollup-linux-arm64-musl": "4.18.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.18.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.18.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.18.0",
-        "@rollup/rollup-linux-x64-gnu": "4.18.0",
-        "@rollup/rollup-linux-x64-musl": "4.18.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.18.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.18.0",
-        "@rollup/rollup-win32-x64-msvc": "4.18.0",
+        "@rollup/rollup-android-arm-eabi": "4.21.2",
+        "@rollup/rollup-android-arm64": "4.21.2",
+        "@rollup/rollup-darwin-arm64": "4.21.2",
+        "@rollup/rollup-darwin-x64": "4.21.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.21.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.21.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.21.2",
+        "@rollup/rollup-linux-arm64-musl": "4.21.2",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.21.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.21.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.21.2",
+        "@rollup/rollup-linux-x64-gnu": "4.21.2",
+        "@rollup/rollup-linux-x64-musl": "4.21.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.21.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.21.2",
+        "@rollup/rollup-win32-x64-msvc": "4.21.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -8522,6 +8477,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -8580,14 +8541,14 @@
       }
     },
     "node_modules/simple-git": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.24.0.tgz",
-      "integrity": "sha512-QqAKee9Twv+3k8IFOFfPB2hnk6as6Y6ACUpwCtQvRYBAes23Wv3SZlHVobAzqcE8gfsisCvPw3HGW3HYM+VYYw==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.26.0.tgz",
+      "integrity": "sha512-5tbkCSzuskR6uA7uA23yjasmA0RzugVo8QM2bpsnxkrgP13eisFT7TMS4a+xKEJvbmr4qf+l0WT3eKa9IxxUyw==",
       "dev": true,
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.4"
+        "debug": "^4.3.5"
       },
       "funding": {
         "type": "github",
@@ -8738,14 +8699,14 @@
       }
     },
     "node_modules/socks-proxy-agent": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.3.tgz",
-      "integrity": "sha512-VNegTZKhuGq5vSD6XNKlbqWhyt/40CgoEw8XxD6dhnm8Jq9IEa3nIa4HwnM8XOqU0CdB0BwWVXusqiFXfHB3+A==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
+      "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
       "dev": true,
       "dependencies": {
         "agent-base": "^7.1.1",
         "debug": "^4.3.4",
-        "socks": "^2.7.1"
+        "socks": "^2.8.3"
       },
       "engines": {
         "node": ">= 14"
@@ -8780,9 +8741,9 @@
       }
     },
     "node_modules/spacetrim": {
-      "version": "0.11.25",
-      "resolved": "https://registry.npmjs.org/spacetrim/-/spacetrim-0.11.25.tgz",
-      "integrity": "sha512-SWxXDROciuJs9YEYXUBjot5k/cqNGPPbT3QmkInFne4AGc1y+76It+jqU8rfsXKt57RRiunzZn1m9+KfuuNklw==",
+      "version": "0.11.39",
+      "resolved": "https://registry.npmjs.org/spacetrim/-/spacetrim-0.11.39.tgz",
+      "integrity": "sha512-S/baW29azJ7py5ausQRE2S6uEDQnlxgMHOEEq4V770ooBDD1/9kZnxRcco/tjZYuDuqYXblCk/r3N13ZmvHZ2g==",
       "dev": true,
       "funding": [
         {
@@ -8828,15 +8789,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/stream-read-all": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/stream-read-all/-/stream-read-all-3.0.1.tgz",
-      "integrity": "sha512-EWZT9XOceBPlVJRrYcykW8jyRSZYbkb/0ZK36uLEmoWVO5gxBOnntNTseNzfREsqxqdfEGQrD8SXQ3QWbBmq8A==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/streamifier": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
@@ -8847,13 +8799,14 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.16.1.tgz",
-      "integrity": "sha512-m9QYj6WygWyWa3H1YY69amr4nVgy61xfjys7xO7kviL5rfIEc2naf+ewFiOA+aEJD7y0JO3h2GoiUv4TDwEGzQ==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.20.0.tgz",
+      "integrity": "sha512-ZGd1LhDeGFucr1CUCTBOS58ZhEendd0ttpGT3usTvosS4ntIwKN9LJFp+OeCSprsCPL14BXVRZlHGRY1V9PVzQ==",
       "dev": true,
       "dependencies": {
-        "fast-fifo": "^1.1.0",
-        "queue-tick": "^1.0.1"
+        "fast-fifo": "^1.3.2",
+        "queue-tick": "^1.0.1",
+        "text-decoder": "^1.1.0"
       },
       "optionalDependencies": {
         "bare-events": "^2.2.0"
@@ -8988,6 +8941,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "dev": true
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -9013,21 +8972,13 @@
       }
     },
     "node_modules/table-layout": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-3.0.2.tgz",
-      "integrity": "sha512-rpyNZYRw+/C+dYkcQ3Pr+rLxW4CfHpXjPDnG7lYhdRoUcZTUt+KEsX+94RGp/aVp/MQU35JCITv2T/beY4m+hw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
       "dev": true,
       "dependencies": {
-        "@75lb/deep-merge": "^1.1.1",
         "array-back": "^6.2.2",
-        "command-line-args": "^5.2.1",
-        "command-line-usage": "^7.0.0",
-        "stream-read-all": "^3.0.1",
-        "typical": "^7.1.1",
         "wordwrapjs": "^5.1.0"
-      },
-      "bin": {
-        "table-layout": "bin/cli.js"
       },
       "engines": {
         "node": ">=12.17"
@@ -9037,15 +8988,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
       "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.17"
-      }
-    },
-    "node_modules/table-layout/node_modules/typical": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-7.1.1.tgz",
-      "integrity": "sha512-T+tKVNs6Wu7IWiAce5BgMd7OZfNYUndHwc5MknN+UHOudi7sGZzuHdCadllRuqJ3fPtgFtIH9+lt9qRv6lmpfA==",
       "dev": true,
       "engines": {
         "node": ">=12.17"
@@ -9095,9 +9037,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.0.tgz",
-      "integrity": "sha512-Q1JFAoUKE5IMfI4Z/lkE/E6+SwgzO+x4tq4v1AyBLRj8VSYvRO6A/rQrPg1yud4g0En9EKI1TvFRF2tQFcoUkg==",
+      "version": "5.31.6",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.6.tgz",
+      "integrity": "sha512-PQ4DAriWzKj+qgehQ7LK5bQqCFNMmlhjR2PFFLuqGCpuCAauxemVBWwWOxo3UIwWQx8+Pr61Df++r76wDmkQBg==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -9117,6 +9059,15 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
+    },
+    "node_modules/text-decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.1.1.tgz",
+      "integrity": "sha512-8zll7REEv4GDD3x4/0pW+ppIxSNs7H1J10IKFZsuOMscumCdM2a+toDGLPA3T+1+fLBql4zbt5z83GEQGGV5VA==",
+      "dev": true,
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -9152,21 +9103,21 @@
       }
     },
     "node_modules/tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
       "dev": true,
       "dependencies": {
-        "punycode": "^2.1.1"
+        "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
       "dev": true
     },
     "node_modules/tsscmp": {
@@ -9188,9 +9139,9 @@
       }
     },
     "node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -9231,9 +9182,9 @@
       }
     },
     "node_modules/ua-parser-js": {
-      "version": "1.0.37",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.37.tgz",
-      "integrity": "sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ==",
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.38.tgz",
+      "integrity": "sha512-Aq5ppTOfvrCMgAPneW1HfWj66Xi7XL+/mIy996R1/CLS/rcyJQm6QZdsKrUeivDFQ+Oc9Wyuwor8Ze8peEoUoQ==",
       "dev": true,
       "funding": [
         {
@@ -9264,9 +9215,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true
     },
     "node_modules/universalify": {
@@ -9285,19 +9236,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/unzipper": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.11.6.tgz",
-      "integrity": "sha512-anERl79akvqLbAxfjIFe4hK0wsi0fH4uGLwNEl4QEnG+KKs3QQeApYgOS/f6vH2EdACUlZg35psmd/3xL2duFQ==",
-      "dev": true,
-      "dependencies": {
-        "big-integer": "^1.6.17",
-        "bluebird": "~3.4.1",
-        "duplexer2": "~0.1.4",
-        "fstream": "^1.0.12",
-        "graceful-fs": "^4.2.2"
       }
     },
     "node_modules/upper-case": {
@@ -9340,9 +9278,9 @@
       "dev": true
     },
     "node_modules/v8-to-istanbul": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
-      "integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
@@ -9468,18 +9406,18 @@
       }
     },
     "node_modules/webdriver": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-8.37.0.tgz",
-      "integrity": "sha512-B2PxFdSpwkVczqerTmu0wUSURxozmk1rs/RUm5FVrsH/qKtKQjkbg21yZr5epoZAwiCYw+F3HaPGChGL74XR8w==",
+      "version": "8.40.3",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-8.40.3.tgz",
+      "integrity": "sha512-mc/pxLpgAQphnIaWvix/QXzp9CJpEvIA3YeF9t5plPaTbvbEaCAYYWkTP6e3vYPYWvx57krjGaYkNUnDCBNolA==",
       "dev": true,
       "dependencies": {
-        "@types/node": "^20.1.0",
+        "@types/node": "^22.2.0",
         "@types/ws": "^8.5.3",
-        "@wdio/config": "8.37.0",
-        "@wdio/logger": "8.28.0",
-        "@wdio/protocols": "8.32.0",
-        "@wdio/types": "8.37.0",
-        "@wdio/utils": "8.37.0",
+        "@wdio/config": "8.40.3",
+        "@wdio/logger": "8.38.0",
+        "@wdio/protocols": "8.40.3",
+        "@wdio/types": "8.40.3",
+        "@wdio/utils": "8.40.3",
         "deepmerge-ts": "^5.1.0",
         "got": "^12.6.1",
         "ky": "^0.33.0",
@@ -9669,35 +9607,36 @@
       }
     },
     "node_modules/webdriverio": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-8.37.0.tgz",
-      "integrity": "sha512-GaL+12fiAdkFJyx4n30tfaJUpPwVELgEsfwumeQLFcqU3ERrM5W1c1QvEzE03oMT4/5NgzPy0lIwcec9pftRWg==",
+      "version": "8.40.5",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-8.40.5.tgz",
+      "integrity": "sha512-fKzaAF8lbgVFWIP8i0eGk22MpjactVVTWP8qtUXDob5Kdo8ffrg1lCKP8mcyrz6fiZM1OY1m6dvkbFelf23Nxw==",
       "dev": true,
       "dependencies": {
-        "@types/node": "^20.1.0",
-        "@wdio/config": "8.37.0",
-        "@wdio/logger": "8.28.0",
-        "@wdio/protocols": "8.32.0",
-        "@wdio/repl": "8.24.12",
-        "@wdio/types": "8.37.0",
-        "@wdio/utils": "8.37.0",
+        "@types/node": "^22.2.0",
+        "@wdio/config": "8.40.3",
+        "@wdio/logger": "8.38.0",
+        "@wdio/protocols": "8.40.3",
+        "@wdio/repl": "8.40.3",
+        "@wdio/types": "8.40.3",
+        "@wdio/utils": "8.40.3",
         "archiver": "^7.0.0",
         "aria-query": "^5.0.0",
         "css-shorthand-properties": "^1.1.1",
         "css-value": "^0.0.1",
-        "devtools-protocol": "^0.0.1302984",
+        "devtools-protocol": "^0.0.1342118",
         "grapheme-splitter": "^1.0.2",
         "import-meta-resolve": "^4.0.0",
         "is-plain-obj": "^4.1.0",
+        "jszip": "^3.10.1",
         "lodash.clonedeep": "^4.5.0",
         "lodash.zip": "^4.2.0",
         "minimatch": "^9.0.0",
-        "puppeteer-core": "^20.9.0",
+        "puppeteer-core": "^21.11.0",
         "query-selector-shadow-dom": "^1.0.0",
         "resq": "^1.9.1",
         "rgb2hex": "0.2.5",
         "serialize-error": "^11.0.1",
-        "webdriver": "8.37.0"
+        "webdriver": "8.40.3"
       },
       "engines": {
         "node": "^16.13 || >=18"
@@ -9712,65 +9651,60 @@
       }
     },
     "node_modules/webdriverio/node_modules/@puppeteer/browsers": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.4.6.tgz",
-      "integrity": "sha512-x4BEjr2SjOPowNeiguzjozQbsc6h437ovD/wu+JpaenxVLm3jkgzHY2xOslMTp50HoTvQreMjiexiGQw1sqZlQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
+      "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
       "dev": true,
       "dependencies": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
         "progress": "2.0.3",
-        "proxy-agent": "6.3.0",
+        "proxy-agent": "6.3.1",
         "tar-fs": "3.0.4",
         "unbzip2-stream": "1.4.3",
-        "yargs": "17.7.1"
+        "yargs": "17.7.2"
       },
       "bin": {
         "browsers": "lib/cjs/main-cli.js"
       },
       "engines": {
         "node": ">=16.3.0"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.7.4"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webdriverio/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/webdriverio/node_modules/chromium-bidi": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.16.tgz",
-      "integrity": "sha512-7ZbXdWERxRxSwo3txsBjjmc/NLxqb1Bk30mRb0BMS4YIaiV6zvKZqL/UAH+DdqcDYayDWk2n/y8klkBDODrPvA==",
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.8.tgz",
+      "integrity": "sha512-blqh+1cEQbHBKmok3rVJkBlBxt9beKBgOsxbFgs7UJcoVbbeZ+K7+6liAsjgpc8l1Xd55cQUy14fXZdGSb4zIw==",
       "dev": true,
       "dependencies": {
-        "mitt": "3.0.0"
+        "mitt": "3.0.1",
+        "urlpattern-polyfill": "10.0.0"
       },
       "peerDependencies": {
         "devtools-protocol": "*"
       }
     },
-    "node_modules/webdriverio/node_modules/devtools-protocol": {
-      "version": "0.0.1302984",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1302984.tgz",
-      "integrity": "sha512-Rgh2Sk5fUSCtEx4QGH9iwTyECdFPySG2nlz5J8guGh2Wlha6uzSOCq/DCEC8faHlLaMPZJMuZ4ovgcX4LvOkKA==",
-      "dev": true
+    "node_modules/webdriverio/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
-    "node_modules/webdriverio/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+    "node_modules/webdriverio/node_modules/devtools-protocol": {
+      "version": "0.0.1342118",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1342118.tgz",
+      "integrity": "sha512-75fMas7PkYNDTmDyb6PRJCH7ILmHLp+BhrZGeMsa4bCh40DTxgCz2NRy5UDzII4C5KuD0oBMZ9vXKhEl6UD/3w==",
       "dev": true
     },
     "node_modules/webdriverio/node_modules/lru-cache": {
@@ -9782,87 +9716,47 @@
         "node": ">=12"
       }
     },
-    "node_modules/webdriverio/node_modules/mitt": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
-      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
-      "dev": true
-    },
     "node_modules/webdriverio/node_modules/proxy-agent": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.0.tgz",
-      "integrity": "sha512-0LdR757eTj/JfuU7TL2YCuAZnxWXu3tkJbg4Oq3geW/qFNT/32T0sp2HnZ9O0lMR4q3vwAt0+xCA8SR0WAD0og==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
+      "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
       "dev": true,
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "^4.3.4",
         "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
         "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.0.0",
+        "pac-proxy-agent": "^7.0.1",
         "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.1"
+        "socks-proxy-agent": "^8.0.2"
       },
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/webdriverio/node_modules/puppeteer-core": {
-      "version": "20.9.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.9.0.tgz",
-      "integrity": "sha512-H9fYZQzMTRrkboEfPmf7m3CLDN6JvbxXA3qTtS+dFt27tR+CsFHzPsT6pzp6lYL6bJbAPaR0HaPO6uSi+F94Pg==",
+      "version": "21.11.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.11.0.tgz",
+      "integrity": "sha512-ArbnyA3U5SGHokEvkfWjW+O8hOxV1RSJxOgriX/3A4xZRqixt9ZFHD0yPgZQF05Qj0oAqi8H/7stDorjoHY90Q==",
       "dev": true,
       "dependencies": {
-        "@puppeteer/browsers": "1.4.6",
-        "chromium-bidi": "0.4.16",
+        "@puppeteer/browsers": "1.9.1",
+        "chromium-bidi": "0.5.8",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1147663",
-        "ws": "8.13.0"
+        "devtools-protocol": "0.0.1232444",
+        "ws": "8.16.0"
       },
       "engines": {
-        "node": ">=16.3.0"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.7.4"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "node": ">=16.13.2"
       }
     },
     "node_modules/webdriverio/node_modules/puppeteer-core/node_modules/devtools-protocol": {
-      "version": "0.0.1147663",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1147663.tgz",
-      "integrity": "sha512-hyWmRrexdhbZ1tcJUGpO95ivbRhWXz++F4Ko+n21AY5PNln2ovoJw+8ZMNDTtip+CNFQfrtLVh/w4009dXO/eQ==",
+      "version": "0.0.1232444",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1232444.tgz",
+      "integrity": "sha512-pM27vqEfxSxRkTMnF+XCmxSEb6duO5R+t8A9DEEJgy4Wz2RVanje2mmj99B6A3zv2r/qGfYlOvYznUhuokizmg==",
       "dev": true
-    },
-    "node_modules/webdriverio/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/webdriverio/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/webdriverio/node_modules/tar-fs": {
       "version": "3.0.4",
@@ -9887,9 +9781,9 @@
       }
     },
     "node_modules/webdriverio/node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -9907,24 +9801,6 @@
         }
       }
     },
-    "node_modules/webdriverio/node_modules/yargs": {
-      "version": "17.7.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -9935,16 +9811,16 @@
       }
     },
     "node_modules/whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
+      "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
       "dev": true,
       "dependencies": {
-        "tr46": "^3.0.0",
+        "tr46": "^5.0.0",
         "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -10313,136 +10189,136 @@
     },
     "packages/accordion": {
       "name": "@scoped-vaadin/accordion",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/details": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/details": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/app-layout": {
       "name": "@scoped-vaadin/app-layout",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/button": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/button": "^23.4.100",
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/avatar": {
       "name": "@scoped-vaadin/avatar",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/item": "^23.4.1",
-        "@scoped-vaadin/list-box": "^23.4.1",
-        "@scoped-vaadin/overlay": "^23.4.1",
-        "@scoped-vaadin/tooltip": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/item": "^23.4.100",
+        "@scoped-vaadin/list-box": "^23.4.100",
+        "@scoped-vaadin/overlay": "^23.4.100",
+        "@scoped-vaadin/tooltip": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/avatar-group": {
       "name": "@scoped-vaadin/avatar-group",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/avatar": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/item": "^23.4.1",
-        "@scoped-vaadin/list-box": "^23.4.1",
-        "@scoped-vaadin/overlay": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/avatar": "^23.4.100",
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/item": "^23.4.100",
+        "@scoped-vaadin/list-box": "^23.4.100",
+        "@scoped-vaadin/overlay": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/button": {
       "name": "@scoped-vaadin/button",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/checkbox": {
       "name": "@scoped-vaadin/checkbox",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/field-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/checkbox-group": {
       "name": "@scoped-vaadin/checkbox-group",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/checkbox": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/checkbox": "^23.4.100",
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/field-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/combo-box": {
       "name": "@scoped-vaadin/combo-box",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/input-container": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/item": "^23.4.1",
-        "@scoped-vaadin/lit-renderer": "^23.4.1",
-        "@scoped-vaadin/overlay": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/field-base": "^23.4.100",
+        "@scoped-vaadin/input-container": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/item": "^23.4.100",
+        "@scoped-vaadin/lit-renderer": "^23.4.100",
+        "@scoped-vaadin/overlay": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/component-base": {
       "name": "@scoped-vaadin/component-base",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
         "@vaadin/vaadin-development-mode-detector": "^2.0.0",
         "@vaadin/vaadin-usage-statistics": "^2.1.0",
         "lit": "^2.0.0 || ^3.0.0"
@@ -10450,700 +10326,700 @@
     },
     "packages/confirm-dialog": {
       "name": "@scoped-vaadin/confirm-dialog",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/button": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/dialog": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/overlay": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/button": "^23.4.100",
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/dialog": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/overlay": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/context-menu": {
       "name": "@scoped-vaadin/context-menu",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/item": "^23.4.1",
-        "@scoped-vaadin/list-box": "^23.4.1",
-        "@scoped-vaadin/lit-renderer": "^23.4.1",
-        "@scoped-vaadin/overlay": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/item": "^23.4.100",
+        "@scoped-vaadin/list-box": "^23.4.100",
+        "@scoped-vaadin/lit-renderer": "^23.4.100",
+        "@scoped-vaadin/overlay": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/custom-field": {
       "name": "@scoped-vaadin/custom-field",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/field-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/date-picker": {
       "name": "@scoped-vaadin/date-picker",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.2.0",
-        "@scoped-vaadin/button": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/input-container": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/overlay": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/button": "^23.4.100",
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/field-base": "^23.4.100",
+        "@scoped-vaadin/input-container": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/overlay": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/date-time-picker": {
       "name": "@scoped-vaadin/date-time-picker",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/custom-field": "^23.4.1",
-        "@scoped-vaadin/date-picker": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/time-picker": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/custom-field": "^23.4.100",
+        "@scoped-vaadin/date-picker": "^23.4.100",
+        "@scoped-vaadin/field-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/time-picker": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/details": {
       "name": "@scoped-vaadin/details",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/field-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/dialog": {
       "name": "@scoped-vaadin/dialog",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/lit-renderer": "^23.4.1",
-        "@scoped-vaadin/overlay": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/lit-renderer": "^23.4.100",
+        "@scoped-vaadin/overlay": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/email-field": {
       "name": "@scoped-vaadin/email-field",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/text-field": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/text-field": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/field-base": {
       "name": "@scoped-vaadin/field-base",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
         "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "packages/field-highlighter": {
       "name": "@scoped-vaadin/field-highlighter",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/overlay": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/overlay": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
         "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "packages/form-layout": {
       "name": "@scoped-vaadin/form-layout",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/grid": {
       "name": "@scoped-vaadin/grid",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/checkbox": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/lit-renderer": "^23.4.1",
-        "@scoped-vaadin/text-field": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/checkbox": "^23.4.100",
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/lit-renderer": "^23.4.100",
+        "@scoped-vaadin/text-field": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/horizontal-layout": {
       "name": "@scoped-vaadin/horizontal-layout",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/icon": {
       "name": "@scoped-vaadin/icon",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
         "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "packages/icons": {
       "name": "@scoped-vaadin/icons",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/iron-icon": "^3.0.0",
         "@polymer/iron-iconset-svg": "^3.0.0",
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/icon": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+        "@scoped-vaadin/icon": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
       }
     },
     "packages/input-container": {
       "name": "@scoped-vaadin/input-container",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/integer-field": {
       "name": "@scoped-vaadin/integer-field",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/number-field": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/number-field": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100"
       }
     },
     "packages/item": {
       "name": "@scoped-vaadin/item",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/list-box": {
       "name": "@scoped-vaadin/list-box",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/item": "^23.4.1",
-        "@scoped-vaadin/vaadin-list-mixin": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/item": "^23.4.100",
+        "@scoped-vaadin/vaadin-list-mixin": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/lit-renderer": {
       "name": "@scoped-vaadin/lit-renderer",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
         "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "packages/login": {
       "name": "@scoped-vaadin/login",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/button": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/overlay": "^23.4.1",
-        "@scoped-vaadin/password-field": "^23.4.1",
-        "@scoped-vaadin/text-field": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/button": "^23.4.100",
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/overlay": "^23.4.100",
+        "@scoped-vaadin/password-field": "^23.4.100",
+        "@scoped-vaadin/text-field": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/menu-bar": {
       "name": "@scoped-vaadin/menu-bar",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/button": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/context-menu": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/button": "^23.4.100",
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/context-menu": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/message-input": {
       "name": "@scoped-vaadin/message-input",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/button": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/text-area": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/button": "^23.4.100",
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/text-area": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/message-list": {
       "name": "@scoped-vaadin/message-list",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/avatar": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/avatar": "^23.4.100",
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/multi-select-combo-box": {
       "name": "@scoped-vaadin/multi-select-combo-box",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/combo-box": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/input-container": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/lit-renderer": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/combo-box": "^23.4.100",
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/field-base": "^23.4.100",
+        "@scoped-vaadin/input-container": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/lit-renderer": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/notification": {
       "name": "@scoped-vaadin/notification",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/lit-renderer": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/lit-renderer": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
         "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "packages/number-field": {
       "name": "@scoped-vaadin/number-field",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/input-container": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/field-base": "^23.4.100",
+        "@scoped-vaadin/input-container": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/overlay": {
       "name": "@scoped-vaadin/overlay",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/password-field": {
       "name": "@scoped-vaadin/password-field",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/button": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/text-field": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/button": "^23.4.100",
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/text-field": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/polymer-legacy-adapter": {
       "name": "@scoped-vaadin/polymer-legacy-adapter",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
         "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "packages/progress-bar": {
       "name": "@scoped-vaadin/progress-bar",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/radio-group": {
       "name": "@scoped-vaadin/radio-group",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/field-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/scroller": {
       "name": "@scoped-vaadin/scroller",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/select": {
       "name": "@scoped-vaadin/select",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.2.0",
-        "@scoped-vaadin/button": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/input-container": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/item": "^23.4.1",
-        "@scoped-vaadin/list-box": "^23.4.1",
-        "@scoped-vaadin/lit-renderer": "^23.4.1",
-        "@scoped-vaadin/overlay": "^23.4.1",
-        "@scoped-vaadin/vaadin-list-mixin": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/button": "^23.4.100",
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/field-base": "^23.4.100",
+        "@scoped-vaadin/input-container": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/item": "^23.4.100",
+        "@scoped-vaadin/list-box": "^23.4.100",
+        "@scoped-vaadin/lit-renderer": "^23.4.100",
+        "@scoped-vaadin/overlay": "^23.4.100",
+        "@scoped-vaadin/vaadin-list-mixin": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/split-layout": {
       "name": "@scoped-vaadin/split-layout",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/tabs": {
       "name": "@scoped-vaadin/tabs",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/item": "^23.4.1",
-        "@scoped-vaadin/vaadin-list-mixin": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/item": "^23.4.100",
+        "@scoped-vaadin/vaadin-list-mixin": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/tabsheet": {
       "name": "@scoped-vaadin/tabsheet",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/scroller": "^23.4.1",
-        "@scoped-vaadin/tabs": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/field-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/scroller": "^23.4.100",
+        "@scoped-vaadin/tabs": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/text-area": {
       "name": "@scoped-vaadin/text-area",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/input-container": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/field-base": "^23.4.100",
+        "@scoped-vaadin/input-container": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/text-field": {
       "name": "@scoped-vaadin/text-field",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/input-container": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/field-base": "^23.4.100",
+        "@scoped-vaadin/input-container": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/time-picker": {
       "name": "@scoped-vaadin/time-picker",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/combo-box": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/input-container": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/combo-box": "^23.4.100",
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/field-base": "^23.4.100",
+        "@scoped-vaadin/input-container": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/tooltip": {
       "name": "@scoped-vaadin/tooltip",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/overlay": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/overlay": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/upload": {
       "name": "@scoped-vaadin/upload",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/button": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/progress-bar": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/button": "^23.4.100",
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/progress-bar": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/vaadin-list-mixin": {
       "name": "@scoped-vaadin/vaadin-list-mixin",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
       }
     },
     "packages/vaadin-lumo-styles": {
       "name": "@scoped-vaadin/vaadin-lumo-styles",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/iron-icon": "^3.0.0",
         "@polymer/iron-iconset-svg": "^3.0.0",
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/icon": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/icon": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/vaadin-material-styles": {
       "name": "@scoped-vaadin/vaadin-material-styles",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/vaadin-themable-mixin": {
       "name": "@scoped-vaadin/vaadin-themable-mixin",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
         "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "packages/vertical-layout": {
       "name": "@scoped-vaadin/vertical-layout",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "packages/virtual-list": {
       "name": "@scoped-vaadin/virtual-list",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/lit-renderer": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
+        "@scoped-vaadin/component-base": "^23.4.100",
+        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100",
+        "@scoped-vaadin/lit-renderer": "^23.4.100",
+        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100"
       }
     },
     "vendor-packages/internal-custom-elements-registry": {
       "name": "@scoped-vaadin/internal-custom-elements-registry",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0"
     },
     "vendor-packages/vaadin-all": {
       "name": "@scoped-vaadin/vaadin-all",
-      "version": "23.4.1",
+      "version": "23.4.100",
       "license": "Apache-2.0",
       "devDependencies": {
         "@vaadin/accordion": "23.4.1",
@@ -11204,8421 +11080,6 @@
         "@vaadin/vertical-layout": "23.4.1",
         "@vaadin/virtual-list": "23.4.1"
       }
-    }
-  },
-  "dependencies": {
-    "@75lb/deep-merge": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@75lb/deep-merge/-/deep-merge-1.1.1.tgz",
-      "integrity": "sha512-xvgv6pkMGBA6GwdyJbNAnDmfAIR/DfWhrj9jgWh3TY7gRm3KO46x/GPjRg6wJ0nOepwqrNxFfojebh0Df4h4Tw==",
-      "dev": true,
-      "requires": {
-        "lodash.assignwith": "^4.2.0",
-        "typical": "^7.1.1"
-      },
-      "dependencies": {
-        "typical": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/typical/-/typical-7.1.1.tgz",
-          "integrity": "sha512-T+tKVNs6Wu7IWiAce5BgMd7OZfNYUndHwc5MknN+UHOudi7sGZzuHdCadllRuqJ3fPtgFtIH9+lt9qRv6lmpfA==",
-          "dev": true
-        }
-      }
-    },
-    "@babel/code-frame": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
-      "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
-      "dev": true,
-      "requires": {
-        "@babel/highlight": "^7.24.2",
-        "picocolors": "^1.0.0"
-      }
-    },
-    "@babel/helper-validator-identifier": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
-      "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
-      "dev": true
-    },
-    "@babel/highlight": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.5.tgz",
-      "integrity": "sha512-8lLmua6AVh/8SLJRRVD6V8p73Hir9w5mJrhE+IPpILG31KKlI9iz5zmBYKcWPS59qSfgP9RaSBQSHHE81WKuEw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-validator-identifier": "^7.24.5",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
-      }
-    },
-    "@eggjs/yauzl": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@eggjs/yauzl/-/yauzl-2.11.0.tgz",
-      "integrity": "sha512-Jq+k2fCZJ3i3HShb0nxLUiAgq5pwo8JTT1TrH22JoehZQ0Nm2dvByGIja1NYfNyuE4Tx5/Dns5nVsBN/mlC8yg==",
-      "dev": true,
-      "requires": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer2": "^1.2.0"
-      }
-    },
-    "@esbuild/aix-ppc64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
-      "integrity": "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/android-arm": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
-      "integrity": "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/android-arm64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz",
-      "integrity": "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/android-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz",
-      "integrity": "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/darwin-arm64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
-      "integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/darwin-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz",
-      "integrity": "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/freebsd-arm64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz",
-      "integrity": "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/freebsd-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz",
-      "integrity": "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-arm": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz",
-      "integrity": "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-arm64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz",
-      "integrity": "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-ia32": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz",
-      "integrity": "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-loong64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz",
-      "integrity": "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-mips64el": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz",
-      "integrity": "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-ppc64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz",
-      "integrity": "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-riscv64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz",
-      "integrity": "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-s390x": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz",
-      "integrity": "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz",
-      "integrity": "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/netbsd-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
-      "integrity": "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/openbsd-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
-      "integrity": "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/sunos-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz",
-      "integrity": "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/win32-arm64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz",
-      "integrity": "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/win32-ia32": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz",
-      "integrity": "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/win32-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz",
-      "integrity": "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==",
-      "dev": true,
-      "optional": true
-    },
-    "@esm-bundle/chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@esm-bundle/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-6Tx35wWiNw7X0nLY9RMx8v3EL8SacCFW+eEZOE9Hc+XxmU5HFE2AFEg+GehUZpiyDGwVvPH75ckGlqC7coIPnA==",
-      "dev": true,
-      "requires": {
-        "@types/chai": "^4.2.12"
-      }
-    },
-    "@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
-      "requires": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      }
-    },
-    "@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true
-    },
-    "@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true
-    },
-    "@jridgewell/source-map": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
-      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25"
-      }
-    },
-    "@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
-    },
-    "@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "@kwsites/file-exists": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
-      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.1.1"
-      }
-    },
-    "@kwsites/promise-deferred": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
-      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
-      "dev": true
-    },
-    "@lit-labs/ssr-dom-shim": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.0.tgz",
-      "integrity": "sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g=="
-    },
-    "@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "requires": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
-    "@mdn/browser-compat-data": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-4.2.1.tgz",
-      "integrity": "sha512-EWUguj2kd7ldmrF9F+vI5hUOralPd+sdsUnYbRy33vZTuZkduC1shE9TtEMEjAQwyfyMb4ole5KtjF8MsnQOlA==",
-      "dev": true
-    },
-    "@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "requires": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      }
-    },
-    "@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true
-    },
-    "@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "requires": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      }
-    },
-    "@open-wc/dedupe-mixin": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-1.4.0.tgz",
-      "integrity": "sha512-Sj7gKl1TLcDbF7B6KUhtvr+1UCxdhMbNY5KxdU5IfMFWqL8oy1ZeAcCANjoB1TL0AJTcPmcCFsCbHf8X2jGDUA=="
-    },
-    "@open-wc/semantic-dom-diff": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.19.9.tgz",
-      "integrity": "sha512-iUL0OPA6PeLQVEEJ/gsgkEiwOGgK4E1KS//zTB+u+OAh0NifNTfxDxIHQa7rEGvplaq2b2zztT2yyzOzj+MlAA==",
-      "dev": true,
-      "requires": {
-        "@types/chai": "^4.3.1",
-        "@web/test-runner-commands": "^0.6.5"
-      },
-      "dependencies": {
-        "@web/browser-logs": {
-          "version": "0.2.6",
-          "resolved": "https://registry.npmjs.org/@web/browser-logs/-/browser-logs-0.2.6.tgz",
-          "integrity": "sha512-CNjNVhd4FplRY8PPWIAt02vAowJAVcOoTNrR/NNb/o9pka7yI9qdjpWrWhEbPr2pOXonWb52AeAgdK66B8ZH7w==",
-          "dev": true,
-          "requires": {
-            "errorstacks": "^2.2.0"
-          }
-        },
-        "@web/dev-server-core": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/@web/dev-server-core/-/dev-server-core-0.4.1.tgz",
-          "integrity": "sha512-KdYwejXZwIZvb6tYMCqU7yBiEOPfKLQ3V9ezqqEz8DA9V9R3oQWaowckvCpFB9IxxPfS/P8/59OkdzGKQjcIUw==",
-          "dev": true,
-          "requires": {
-            "@types/koa": "^2.11.6",
-            "@types/ws": "^7.4.0",
-            "@web/parse5-utils": "^1.3.1",
-            "chokidar": "^3.4.3",
-            "clone": "^2.1.2",
-            "es-module-lexer": "^1.0.0",
-            "get-stream": "^6.0.0",
-            "is-stream": "^2.0.0",
-            "isbinaryfile": "^5.0.0",
-            "koa": "^2.13.0",
-            "koa-etag": "^4.0.0",
-            "koa-send": "^5.0.1",
-            "koa-static": "^5.0.0",
-            "lru-cache": "^6.0.0",
-            "mime-types": "^2.1.27",
-            "parse5": "^6.0.1",
-            "picomatch": "^2.2.2",
-            "ws": "^7.4.2"
-          }
-        },
-        "@web/parse5-utils": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/@web/parse5-utils/-/parse5-utils-1.3.1.tgz",
-          "integrity": "sha512-haCgDchZrAOB9EhBJ5XqiIjBMsS/exsM5Ru7sCSyNkXVEJWskyyKuKMFk66BonnIGMPpDtqDrTUfYEis5Zi3XA==",
-          "dev": true,
-          "requires": {
-            "@types/parse5": "^6.0.1",
-            "parse5": "^6.0.1"
-          }
-        },
-        "@web/test-runner-commands": {
-          "version": "0.6.6",
-          "resolved": "https://registry.npmjs.org/@web/test-runner-commands/-/test-runner-commands-0.6.6.tgz",
-          "integrity": "sha512-2DcK/+7f8QTicQpGFq/TmvKHDK/6Zald6rn1zqRlmj3pcH8fX6KHNVMU60Za9QgAKdorMBPfd8dJwWba5otzdw==",
-          "dev": true,
-          "requires": {
-            "@web/test-runner-core": "^0.10.29",
-            "mkdirp": "^1.0.4"
-          }
-        },
-        "@web/test-runner-core": {
-          "version": "0.10.29",
-          "resolved": "https://registry.npmjs.org/@web/test-runner-core/-/test-runner-core-0.10.29.tgz",
-          "integrity": "sha512-0/ZALYaycEWswHhpyvl5yqo0uIfCmZe8q14nGPi1dMmNiqLcHjyFGnuIiLexI224AW74ljHcHllmDlXK9FUKGA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.12.11",
-            "@types/babel__code-frame": "^7.0.2",
-            "@types/co-body": "^6.1.0",
-            "@types/convert-source-map": "^2.0.0",
-            "@types/debounce": "^1.2.0",
-            "@types/istanbul-lib-coverage": "^2.0.3",
-            "@types/istanbul-reports": "^3.0.0",
-            "@web/browser-logs": "^0.2.6",
-            "@web/dev-server-core": "^0.4.1",
-            "chokidar": "^3.4.3",
-            "cli-cursor": "^3.1.0",
-            "co-body": "^6.1.0",
-            "convert-source-map": "^2.0.0",
-            "debounce": "^1.2.0",
-            "dependency-graph": "^0.11.0",
-            "globby": "^11.0.1",
-            "ip": "^1.1.5",
-            "istanbul-lib-coverage": "^3.0.0",
-            "istanbul-lib-report": "^3.0.0",
-            "istanbul-reports": "^3.0.2",
-            "log-update": "^4.0.0",
-            "nanocolors": "^0.2.1",
-            "nanoid": "^3.1.25",
-            "open": "^8.0.2",
-            "picomatch": "^2.2.2",
-            "source-map": "^0.7.3"
-          }
-        },
-        "ip": {
-          "version": "1.1.9",
-          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
-          "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        }
-      }
-    },
-    "@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
-      "optional": true
-    },
-    "@polymer/iron-a11y-keys-behavior": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/iron-a11y-keys-behavior/-/iron-a11y-keys-behavior-3.0.1.tgz",
-      "integrity": "sha512-lnrjKq3ysbBPT/74l0Fj0U9H9C35Tpw2C/tpJ8a+5g8Y3YJs1WSZYnEl1yOkw6sEyaxOq/1DkzH0+60gGu5/PQ==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@polymer/iron-fit-behavior": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@polymer/iron-fit-behavior/-/iron-fit-behavior-3.1.0.tgz",
-      "integrity": "sha512-ABcgIYqrjhmUT8tiuolqeGttF/8pd3sEymUDrO1vXbZu4FWIvoLNndrMDFvs++AGd12Mjf5pYy84NJc6dB8Vig==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@polymer/iron-flex-layout": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/iron-flex-layout/-/iron-flex-layout-3.0.1.tgz",
-      "integrity": "sha512-7gB869czArF+HZcPTVSgvA7tXYFze9EKckvM95NB7SqYF+NnsQyhoXgKnpFwGyo95lUjUW9TFDLUwDXnCYFtkw==",
-      "requires": {
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@polymer/iron-icon": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/iron-icon/-/iron-icon-3.0.1.tgz",
-      "integrity": "sha512-QLPwirk+UPZNaLnMew9VludXA4CWUCenRewgEcGYwdzVgDPCDbXxy6vRJjmweZobMQv/oVLppT2JZtJFnPxX6g==",
-      "requires": {
-        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
-        "@polymer/iron-meta": "^3.0.0-pre.26",
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@polymer/iron-iconset-svg": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/iron-iconset-svg/-/iron-iconset-svg-3.0.1.tgz",
-      "integrity": "sha512-XNwURbNHRw6u2fJe05O5fMYye6GSgDlDqCO+q6K1zAnKIrpgZwf2vTkBd5uCcZwsN0FyCB3mvNZx4jkh85dRDw==",
-      "requires": {
-        "@polymer/iron-meta": "^3.0.0-pre.26",
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@polymer/iron-meta": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/iron-meta/-/iron-meta-3.0.1.tgz",
-      "integrity": "sha512-pWguPugiLYmWFV9UWxLWzZ6gm4wBwQdDy4VULKwdHCqR7OP7u98h+XDdGZsSlDPv6qoryV/e3tGHlTIT0mbzJA==",
-      "requires": {
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@polymer/iron-overlay-behavior": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@polymer/iron-overlay-behavior/-/iron-overlay-behavior-3.0.3.tgz",
-      "integrity": "sha512-Q/Fp0+uOQQ145ebZ7T8Cxl4m1tUKYjyymkjcL2rXUm+aDQGb1wA1M1LYxUF5YBqd+9lipE0PTIiYwA2ZL/sznA==",
-      "dev": true,
-      "requires": {
-        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
-        "@polymer/iron-fit-behavior": "^3.0.0-pre.26",
-        "@polymer/iron-resizable-behavior": "^3.0.0-pre.26",
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@polymer/iron-resizable-behavior": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/iron-resizable-behavior/-/iron-resizable-behavior-3.0.1.tgz",
-      "integrity": "sha512-FyHxRxFspVoRaeZSWpT3y0C9awomb4tXXolIJcZ7RvXhMP632V5lez+ch5G5SwK0LpnAPkg35eB0LPMFv+YMMQ==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@polymer/polymer": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.5.1.tgz",
-      "integrity": "sha512-JlAHuy+1qIC6hL1ojEUfIVD58fzTpJAoCxFwV5yr0mYTXV1H8bz5zy0+rC963Cgr9iNXQ4T9ncSjC2fkF9BQfw==",
-      "requires": {
-        "@webcomponents/shadycss": "^1.9.1"
-      }
-    },
-    "@promptbook/utils": {
-      "version": "0.50.0-10",
-      "resolved": "https://registry.npmjs.org/@promptbook/utils/-/utils-0.50.0-10.tgz",
-      "integrity": "sha512-Z94YoY/wcZb5m1QoXgmIC1rVeDguGK5bWmUTYdWCqh/LHVifRdJ1C+tBzS0h+HMOD0XzMjZhBQ/mBgTZ/QNW/g==",
-      "dev": true,
-      "requires": {
-        "moment": "2.30.1",
-        "prettier": "2.8.1",
-        "spacetrim": "0.11.25"
-      }
-    },
-    "@puppeteer/browsers": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.3.0.tgz",
-      "integrity": "sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.3.5",
-        "extract-zip": "^2.0.1",
-        "progress": "^2.0.3",
-        "proxy-agent": "^6.4.0",
-        "semver": "^7.6.3",
-        "tar-fs": "^3.0.6",
-        "unbzip2-stream": "^1.4.3",
-        "yargs": "^17.7.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-          "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
-      }
-    },
-    "@rollup/plugin-node-resolve": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.3.tgz",
-      "integrity": "sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==",
-      "dev": true,
-      "requires": {
-        "@rollup/pluginutils": "^5.0.1",
-        "@types/resolve": "1.20.2",
-        "deepmerge": "^4.2.2",
-        "is-builtin-module": "^3.2.1",
-        "is-module": "^1.0.0",
-        "resolve": "^1.22.1"
-      }
-    },
-    "@rollup/pluginutils": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
-      "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
-      "dev": true,
-      "requires": {
-        "@types/estree": "^1.0.0",
-        "estree-walker": "^2.0.2",
-        "picomatch": "^2.3.1"
-      }
-    },
-    "@rollup/rollup-android-arm-eabi": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.18.0.tgz",
-      "integrity": "sha512-Tya6xypR10giZV1XzxmH5wr25VcZSncG0pZIjfePT0OVBvqNEurzValetGNarVrGiq66EBVAFn15iYX4w6FKgQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@rollup/rollup-android-arm64": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.18.0.tgz",
-      "integrity": "sha512-avCea0RAP03lTsDhEyfy+hpfr85KfyTctMADqHVhLAF3MlIkq83CP8UfAHUssgXTYd+6er6PaAhx/QGv4L1EiA==",
-      "dev": true,
-      "optional": true
-    },
-    "@rollup/rollup-darwin-arm64": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.18.0.tgz",
-      "integrity": "sha512-IWfdwU7KDSm07Ty0PuA/W2JYoZ4iTj3TUQjkVsO/6U+4I1jN5lcR71ZEvRh52sDOERdnNhhHU57UITXz5jC1/w==",
-      "dev": true,
-      "optional": true
-    },
-    "@rollup/rollup-darwin-x64": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.18.0.tgz",
-      "integrity": "sha512-n2LMsUz7Ynu7DoQrSQkBf8iNrjOGyPLrdSg802vk6XT3FtsgX6JbE8IHRvposskFm9SNxzkLYGSq9QdpLYpRNA==",
-      "dev": true,
-      "optional": true
-    },
-    "@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.18.0.tgz",
-      "integrity": "sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==",
-      "dev": true,
-      "optional": true
-    },
-    "@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.18.0.tgz",
-      "integrity": "sha512-l3m9ewPgjQSXrUMHg93vt0hYCGnrMOcUpTz6FLtbwljo2HluS4zTXFy2571YQbisTnfTKPZ01u/ukJdQTLGh9A==",
-      "dev": true,
-      "optional": true
-    },
-    "@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.18.0.tgz",
-      "integrity": "sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==",
-      "dev": true,
-      "optional": true
-    },
-    "@rollup/rollup-linux-arm64-musl": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.18.0.tgz",
-      "integrity": "sha512-be6Yx37b24ZwxQ+wOQXXLZqpq4jTckJhtGlWGZs68TgdKXJgw54lUUoFYrg6Zs/kjzAQwEwYbp8JxZVzZLRepQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.18.0.tgz",
-      "integrity": "sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==",
-      "dev": true,
-      "optional": true
-    },
-    "@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.18.0.tgz",
-      "integrity": "sha512-ROCM7i+m1NfdrsmvwSzoxp9HFtmKGHEqu5NNDiZWQtXLA8S5HBCkVvKAxJ8U+CVctHwV2Gb5VUaK7UAkzhDjlg==",
-      "dev": true,
-      "optional": true
-    },
-    "@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.18.0.tgz",
-      "integrity": "sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==",
-      "dev": true,
-      "optional": true
-    },
-    "@rollup/rollup-linux-x64-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.18.0.tgz",
-      "integrity": "sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==",
-      "dev": true,
-      "optional": true
-    },
-    "@rollup/rollup-linux-x64-musl": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.18.0.tgz",
-      "integrity": "sha512-LKaqQL9osY/ir2geuLVvRRs+utWUNilzdE90TpyoX0eNqPzWjRm14oMEE+YLve4k/NAqCdPkGYDaDF5Sw+xBfg==",
-      "dev": true,
-      "optional": true
-    },
-    "@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.18.0.tgz",
-      "integrity": "sha512-7J6TkZQFGo9qBKH0pk2cEVSRhJbL6MtfWxth7Y5YmZs57Pi+4x6c2dStAUvaQkHQLnEQv1jzBUW43GvZW8OFqA==",
-      "dev": true,
-      "optional": true
-    },
-    "@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.18.0.tgz",
-      "integrity": "sha512-Txjh+IxBPbkUB9+SXZMpv+b/vnTEtFyfWZgJ6iyCmt2tdx0OF5WhFowLmnh8ENGNpfUlUZkdI//4IEmhwPieNg==",
-      "dev": true,
-      "optional": true
-    },
-    "@rollup/rollup-win32-x64-msvc": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.18.0.tgz",
-      "integrity": "sha512-UOo5FdvOL0+eIVTgS4tIdbW+TtnBLWg1YBCcU2KWM7nuNwRz9bksDX1bekJJCpu25N1DVWaCwnT39dVQxzqS8g==",
-      "dev": true,
-      "optional": true
-    },
-    "@scoped-vaadin/accordion": {
-      "version": "file:packages/accordion",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/details": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/app-layout": {
-      "version": "file:packages/app-layout",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/button": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/avatar": {
-      "version": "file:packages/avatar",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/item": "^23.4.1",
-        "@scoped-vaadin/list-box": "^23.4.1",
-        "@scoped-vaadin/overlay": "^23.4.1",
-        "@scoped-vaadin/tooltip": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/avatar-group": {
-      "version": "file:packages/avatar-group",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/avatar": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/item": "^23.4.1",
-        "@scoped-vaadin/list-box": "^23.4.1",
-        "@scoped-vaadin/overlay": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/button": {
-      "version": "file:packages/button",
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/checkbox": {
-      "version": "file:packages/checkbox",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/checkbox-group": {
-      "version": "file:packages/checkbox-group",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/checkbox": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/combo-box": {
-      "version": "file:packages/combo-box",
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/input-container": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/item": "^23.4.1",
-        "@scoped-vaadin/lit-renderer": "^23.4.1",
-        "@scoped-vaadin/overlay": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/component-base": {
-      "version": "file:packages/component-base",
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-        "@vaadin/vaadin-usage-statistics": "^2.1.0",
-        "lit": "^2.0.0 || ^3.0.0"
-      }
-    },
-    "@scoped-vaadin/confirm-dialog": {
-      "version": "file:packages/confirm-dialog",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/button": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/dialog": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/overlay": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/context-menu": {
-      "version": "file:packages/context-menu",
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/item": "^23.4.1",
-        "@scoped-vaadin/list-box": "^23.4.1",
-        "@scoped-vaadin/lit-renderer": "^23.4.1",
-        "@scoped-vaadin/overlay": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/custom-field": {
-      "version": "file:packages/custom-field",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/date-picker": {
-      "version": "file:packages/date-picker",
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.2.0",
-        "@scoped-vaadin/button": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/input-container": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/overlay": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/date-time-picker": {
-      "version": "file:packages/date-time-picker",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/custom-field": "^23.4.1",
-        "@scoped-vaadin/date-picker": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/time-picker": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/details": {
-      "version": "file:packages/details",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/dialog": {
-      "version": "file:packages/dialog",
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/lit-renderer": "^23.4.1",
-        "@scoped-vaadin/overlay": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/email-field": {
-      "version": "file:packages/email-field",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/text-field": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/field-base": {
-      "version": "file:packages/field-base",
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "lit": "^2.0.0 || ^3.0.0"
-      }
-    },
-    "@scoped-vaadin/field-highlighter": {
-      "version": "file:packages/field-highlighter",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/overlay": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-        "lit": "^2.0.0 || ^3.0.0"
-      }
-    },
-    "@scoped-vaadin/form-layout": {
-      "version": "file:packages/form-layout",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/grid": {
-      "version": "file:packages/grid",
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/checkbox": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/lit-renderer": "^23.4.1",
-        "@scoped-vaadin/text-field": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/horizontal-layout": {
-      "version": "file:packages/horizontal-layout",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/icon": {
-      "version": "file:packages/icon",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-        "lit": "^2.0.0 || ^3.0.0"
-      }
-    },
-    "@scoped-vaadin/icons": {
-      "version": "file:packages/icons",
-      "requires": {
-        "@polymer/iron-icon": "^3.0.0",
-        "@polymer/iron-iconset-svg": "^3.0.0",
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/icon": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/input-container": {
-      "version": "file:packages/input-container",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/integer-field": {
-      "version": "file:packages/integer-field",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/number-field": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/internal-custom-elements-registry": {
-      "version": "file:vendor-packages/internal-custom-elements-registry"
-    },
-    "@scoped-vaadin/item": {
-      "version": "file:packages/item",
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/list-box": {
-      "version": "file:packages/list-box",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/item": "^23.4.1",
-        "@scoped-vaadin/vaadin-list-mixin": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/lit-renderer": {
-      "version": "file:packages/lit-renderer",
-      "requires": {
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "lit": "^2.0.0 || ^3.0.0"
-      }
-    },
-    "@scoped-vaadin/login": {
-      "version": "file:packages/login",
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/button": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/overlay": "^23.4.1",
-        "@scoped-vaadin/password-field": "^23.4.1",
-        "@scoped-vaadin/text-field": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/menu-bar": {
-      "version": "file:packages/menu-bar",
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/button": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/context-menu": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/message-input": {
-      "version": "file:packages/message-input",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/button": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/text-area": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/message-list": {
-      "version": "file:packages/message-list",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/avatar": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/multi-select-combo-box": {
-      "version": "file:packages/multi-select-combo-box",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/combo-box": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/input-container": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/lit-renderer": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/notification": {
-      "version": "file:packages/notification",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/lit-renderer": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-        "lit": "^2.0.0 || ^3.0.0"
-      }
-    },
-    "@scoped-vaadin/number-field": {
-      "version": "file:packages/number-field",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/input-container": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/overlay": {
-      "version": "file:packages/overlay",
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/password-field": {
-      "version": "file:packages/password-field",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/button": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/text-field": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/polymer-legacy-adapter": {
-      "version": "file:packages/polymer-legacy-adapter",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-        "lit": "^2.0.0 || ^3.0.0"
-      }
-    },
-    "@scoped-vaadin/progress-bar": {
-      "version": "file:packages/progress-bar",
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/radio-group": {
-      "version": "file:packages/radio-group",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/scroller": {
-      "version": "file:packages/scroller",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/select": {
-      "version": "file:packages/select",
-      "requires": {
-        "@polymer/polymer": "^3.2.0",
-        "@scoped-vaadin/button": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/input-container": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/item": "^23.4.1",
-        "@scoped-vaadin/list-box": "^23.4.1",
-        "@scoped-vaadin/lit-renderer": "^23.4.1",
-        "@scoped-vaadin/overlay": "^23.4.1",
-        "@scoped-vaadin/vaadin-list-mixin": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/split-layout": {
-      "version": "file:packages/split-layout",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/tabs": {
-      "version": "file:packages/tabs",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/item": "^23.4.1",
-        "@scoped-vaadin/vaadin-list-mixin": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/tabsheet": {
-      "version": "file:packages/tabsheet",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/scroller": "^23.4.1",
-        "@scoped-vaadin/tabs": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/text-area": {
-      "version": "file:packages/text-area",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/input-container": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/text-field": {
-      "version": "file:packages/text-field",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/input-container": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/time-picker": {
-      "version": "file:packages/time-picker",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/combo-box": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/field-base": "^23.4.1",
-        "@scoped-vaadin/input-container": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/tooltip": {
-      "version": "file:packages/tooltip",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/overlay": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/upload": {
-      "version": "file:packages/upload",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/button": "^23.4.1",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/progress-bar": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/vaadin-all": {
-      "version": "file:vendor-packages/vaadin-all",
-      "requires": {
-        "@vaadin/accordion": "23.4.1",
-        "@vaadin/app-layout": "23.4.1",
-        "@vaadin/avatar": "23.4.1",
-        "@vaadin/avatar-group": "23.4.1",
-        "@vaadin/button": "23.4.1",
-        "@vaadin/checkbox": "23.4.1",
-        "@vaadin/checkbox-group": "23.4.1",
-        "@vaadin/combo-box": "23.4.1",
-        "@vaadin/component-base": "23.4.1",
-        "@vaadin/confirm-dialog": "23.4.1",
-        "@vaadin/context-menu": "23.4.1",
-        "@vaadin/custom-field": "23.4.1",
-        "@vaadin/date-picker": "23.4.1",
-        "@vaadin/date-time-picker": "23.4.1",
-        "@vaadin/details": "23.4.1",
-        "@vaadin/dialog": "23.4.1",
-        "@vaadin/email-field": "23.4.1",
-        "@vaadin/field-base": "23.4.1",
-        "@vaadin/field-highlighter": "23.4.1",
-        "@vaadin/form-layout": "23.4.1",
-        "@vaadin/grid": "23.4.1",
-        "@vaadin/horizontal-layout": "23.4.1",
-        "@vaadin/icon": "23.4.1",
-        "@vaadin/icons": "23.4.1",
-        "@vaadin/input-container": "23.4.1",
-        "@vaadin/integer-field": "23.4.1",
-        "@vaadin/item": "23.4.1",
-        "@vaadin/list-box": "23.4.1",
-        "@vaadin/lit-renderer": "23.4.1",
-        "@vaadin/login": "23.4.1",
-        "@vaadin/menu-bar": "23.4.1",
-        "@vaadin/message-input": "23.4.1",
-        "@vaadin/message-list": "23.4.1",
-        "@vaadin/multi-select-combo-box": "23.4.1",
-        "@vaadin/notification": "23.4.1",
-        "@vaadin/number-field": "23.4.1",
-        "@vaadin/overlay": "23.4.1",
-        "@vaadin/password-field": "23.4.1",
-        "@vaadin/polymer-legacy-adapter": "23.4.1",
-        "@vaadin/progress-bar": "23.4.1",
-        "@vaadin/radio-group": "23.4.1",
-        "@vaadin/scroller": "23.4.1",
-        "@vaadin/select": "23.4.1",
-        "@vaadin/split-layout": "23.4.1",
-        "@vaadin/tabs": "23.4.1",
-        "@vaadin/tabsheet": "23.4.1",
-        "@vaadin/text-area": "23.4.1",
-        "@vaadin/text-field": "23.4.1",
-        "@vaadin/time-picker": "23.4.1",
-        "@vaadin/tooltip": "23.4.1",
-        "@vaadin/upload": "23.4.1",
-        "@vaadin/vaadin-list-mixin": "23.4.1",
-        "@vaadin/vaadin-lumo-styles": "23.4.1",
-        "@vaadin/vaadin-material-styles": "23.4.1",
-        "@vaadin/vaadin-themable-mixin": "23.4.1",
-        "@vaadin/vertical-layout": "23.4.1",
-        "@vaadin/virtual-list": "23.4.1"
-      }
-    },
-    "@scoped-vaadin/vaadin-list-mixin": {
-      "version": "file:packages/vaadin-list-mixin",
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/vaadin-lumo-styles": {
-      "version": "file:packages/vaadin-lumo-styles",
-      "requires": {
-        "@polymer/iron-icon": "^3.0.0",
-        "@polymer/iron-iconset-svg": "^3.0.0",
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/icon": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/vaadin-material-styles": {
-      "version": "file:packages/vaadin-material-styles",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/vaadin-themable-mixin": {
-      "version": "file:packages/vaadin-themable-mixin",
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "lit": "^2.0.0 || ^3.0.0"
-      }
-    },
-    "@scoped-vaadin/vertical-layout": {
-      "version": "file:packages/vertical-layout",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@scoped-vaadin/virtual-list": {
-      "version": "file:packages/virtual-list",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@scoped-vaadin/component-base": "^23.4.1",
-        "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "@scoped-vaadin/lit-renderer": "^23.4.1",
-        "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-        "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1"
-      }
-    },
-    "@sindresorhus/is": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-      "dev": true
-    },
-    "@sinonjs/commons": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
-      "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
-      "dev": true,
-      "requires": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "@sinonjs/fake-timers": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
-      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^1.7.0"
-      }
-    },
-    "@sinonjs/samsam": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.3.tgz",
-      "integrity": "sha512-nhOb2dWPeb1sd3IQXL/dVPnKHDOAFfvichtBf4xV00/rU1QbPCQqKMbvIheIjqwVjh7qIgf2AHTHi391yMOMpQ==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^1.6.0",
-        "lodash.get": "^4.4.2",
-        "type-detect": "^4.0.8"
-      }
-    },
-    "@sinonjs/text-encoding": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
-      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
-      "dev": true
-    },
-    "@szmarczak/http-timer": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
-      "dev": true,
-      "requires": {
-        "defer-to-connect": "^2.0.0"
-      }
-    },
-    "@tootallnate/quickjs-emscripten": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-      "dev": true
-    },
-    "@types/accepts": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.7.tgz",
-      "integrity": "sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/babel__code-frame": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@types/babel__code-frame/-/babel__code-frame-7.0.6.tgz",
-      "integrity": "sha512-Anitqkl3+KrzcW2k77lRlg/GfLZLWXBuNgbEcIOU6M92yw42vsd3xV/Z/yAHEj8m+KUjL6bWOVOFqX8PFPJ4LA==",
-      "dev": true
-    },
-    "@types/body-parser": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
-      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
-      "dev": true,
-      "requires": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/cacheable-request": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
-      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
-      "dev": true,
-      "requires": {
-        "@types/http-cache-semantics": "*",
-        "@types/keyv": "^3.1.4",
-        "@types/node": "*",
-        "@types/responselike": "^1.0.0"
-      }
-    },
-    "@types/chai": {
-      "version": "4.3.16",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.16.tgz",
-      "integrity": "sha512-PatH4iOdyh3MyWtmHVFXLWCCIhUbopaltqddG9BzB+gMIzee2MJrvd+jouii9Z3wzQJruGWAm7WOMjgfG8hQlQ==",
-      "dev": true
-    },
-    "@types/co-body": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@types/co-body/-/co-body-6.1.3.tgz",
-      "integrity": "sha512-UhuhrQ5hclX6UJctv5m4Rfp52AfG9o9+d9/HwjxhVB5NjXxr5t9oKgJxN8xRHgr35oo8meUEHUPFWiKg6y71aA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "@types/qs": "*"
-      }
-    },
-    "@types/command-line-args": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
-      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
-      "dev": true
-    },
-    "@types/connect": {
-      "version": "3.4.38",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/content-disposition": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.8.tgz",
-      "integrity": "sha512-QVSSvno3dE0MgO76pJhmv4Qyi/j0Yk9pBp0Y7TJ2Tlj+KCgJWY6qX7nnxCOLkZ3VYRSIk1WTxCvwUSdx6CCLdg==",
-      "dev": true
-    },
-    "@types/convert-source-map": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/convert-source-map/-/convert-source-map-2.0.3.tgz",
-      "integrity": "sha512-ag0BfJLZf6CQz8VIuRIEYQ5Ggwk/82uvTQf27RcpyDNbY0Vw49LIPqAxk5tqYfrCs9xDaIMvl4aj7ZopnYL8bA==",
-      "dev": true
-    },
-    "@types/cookies": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.9.0.tgz",
-      "integrity": "sha512-40Zk8qR147RABiQ7NQnBzWzDcjKzNrntB5BAmeGCb2p/MIyOE+4BVvc17wumsUqUw00bJYqoXFHYygQnEFh4/Q==",
-      "dev": true,
-      "requires": {
-        "@types/connect": "*",
-        "@types/express": "*",
-        "@types/keygrip": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/debounce": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@types/debounce/-/debounce-1.2.4.tgz",
-      "integrity": "sha512-jBqiORIzKDOToaF63Fm//haOCHuwQuLa2202RK4MozpA6lh93eCBc+/8+wZn5OzjJt3ySdc+74SXWXB55Ewtyw==",
-      "dev": true
-    },
-    "@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true
-    },
-    "@types/express": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
-      "dev": true,
-      "requires": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "@types/express-serve-static-core": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.1.tgz",
-      "integrity": "sha512-ej0phymbFLoCB26dbbq5PGScsf2JAJ4IJHjG10LalgUV36XKTmA4GdA+PVllKvRk0sEKt64X8975qFnkSi0hqA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
-    },
-    "@types/http-assert": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.5.tgz",
-      "integrity": "sha512-4+tE/lwdAahgZT1g30Jkdm9PzFRde0xwxBNUyRsCitRvCQB90iuA2uJYdUnhnANRcqGXaWOGY4FEoxeElNAK2g==",
-      "dev": true
-    },
-    "@types/http-cache-semantics": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
-      "dev": true
-    },
-    "@types/http-errors": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-      "dev": true
-    },
-    "@types/istanbul-lib-coverage": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
-      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-      "dev": true
-    },
-    "@types/istanbul-lib-report": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
-      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
-      "dev": true,
-      "requires": {
-        "@types/istanbul-lib-coverage": "*"
-      }
-    },
-    "@types/istanbul-reports": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
-      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
-      "dev": true,
-      "requires": {
-        "@types/istanbul-lib-report": "*"
-      }
-    },
-    "@types/keygrip": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.6.tgz",
-      "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ==",
-      "dev": true
-    },
-    "@types/keyv": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
-      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/koa": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.15.0.tgz",
-      "integrity": "sha512-7QFsywoE5URbuVnG3loe03QXuGajrnotr3gQkXcEBShORai23MePfFYdhz90FEtBBpkyIYQbVD+evKtloCgX3g==",
-      "dev": true,
-      "requires": {
-        "@types/accepts": "*",
-        "@types/content-disposition": "*",
-        "@types/cookies": "*",
-        "@types/http-assert": "*",
-        "@types/http-errors": "*",
-        "@types/keygrip": "*",
-        "@types/koa-compose": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/koa-compose": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.8.tgz",
-      "integrity": "sha512-4Olc63RY+MKvxMwVknCUDhRQX1pFQoBZ/lXcRLP69PQkEpze/0cr8LNqJQe5NFb/b19DWi2a5bTi2VAlQzhJuA==",
-      "dev": true,
-      "requires": {
-        "@types/koa": "*"
-      }
-    },
-    "@types/mime": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true
-    },
-    "@types/mkdirp": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.2.tgz",
-      "integrity": "sha512-o0K1tSO0Dx5X6xlU5F1D6625FawhC3dU3iqr25lluNv/+/QIVH8RLNEiVokgIZo+mz+87w/3Mkg/VvQS+J51fQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/node": {
-      "version": "20.12.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
-      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
-      "dev": true,
-      "requires": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "@types/parse5": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
-      "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==",
-      "dev": true
-    },
-    "@types/pixelmatch": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@types/pixelmatch/-/pixelmatch-5.2.6.tgz",
-      "integrity": "sha512-wC83uexE5KGuUODn6zkm9gMzTwdY5L0chiK+VrKcDfEjzxh1uadlWTvOmAbCpnM9zx/Ww3f8uKlYQVnO/TrqVg==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/pngjs": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/@types/pngjs/-/pngjs-6.0.5.tgz",
-      "integrity": "sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/qs": {
-      "version": "6.9.15",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
-      "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==",
-      "dev": true
-    },
-    "@types/range-parser": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true
-    },
-    "@types/resolve": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
-      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
-      "dev": true
-    },
-    "@types/responselike": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
-      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/send": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
-      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
-      "dev": true,
-      "requires": {
-        "@types/mime": "^1",
-        "@types/node": "*"
-      }
-    },
-    "@types/serve-static": {
-      "version": "1.15.7",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
-      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
-      "dev": true,
-      "requires": {
-        "@types/http-errors": "*",
-        "@types/node": "*",
-        "@types/send": "*"
-      }
-    },
-    "@types/trusted-types": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
-    },
-    "@types/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-113D3mDkZDjo+EeUEHCFy0qniNc1ZpecGiAU7WSo7YDoSzolZIQKpYFHrPpjkB2nuyahcKfrmLXeQlh7gqJYdw==",
-      "dev": true
-    },
-    "@types/ws": {
-      "version": "7.4.7",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
-      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@vaadin/accordion": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/accordion/-/accordion-23.4.1.tgz",
-      "integrity": "sha512-Kxja9GKcljCplGsQtpgKtK6Fap7IX4K2C8z65bBq4zlxseY2OgP6OaQu95Sh7Csmh0aasriuHHjBAHeAXGj64A==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/details": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/app-layout": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/app-layout/-/app-layout-23.4.1.tgz",
-      "integrity": "sha512-4V83BrJNjvqmDjiEjqoROWVU1LL3rBfEjkwV0yYGgPPhq0BAnMJscE+u38agu+EkawUgj+3Gqtpts0ntzGO6WA==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/button": "~23.4.1",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/avatar": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/avatar/-/avatar-23.4.1.tgz",
-      "integrity": "sha512-SqtxFfCnprSiJLgnHCRdF6h78c7+2EYMAPLsEaaML5kJeP5mcljcy+luzFNCtk52UIcJ1I7cL9rNZ7UkIJSV3A==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/item": "~23.4.1",
-        "@vaadin/list-box": "~23.4.1",
-        "@vaadin/overlay": "~23.4.1",
-        "@vaadin/tooltip": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/avatar-group": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/avatar-group/-/avatar-group-23.4.1.tgz",
-      "integrity": "sha512-Lj9NWtvNKmjIxNB8r/H/IokF3qZFu4JVDMrcE1AHcS8QW2VT+3E5j8G9+sOO2JTeg4yBQM/6QUoglmLOr7aYww==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/avatar": "~23.4.1",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/item": "~23.4.1",
-        "@vaadin/list-box": "~23.4.1",
-        "@vaadin/overlay": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/button": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/button/-/button-23.4.1.tgz",
-      "integrity": "sha512-d8KN9sOj/04oLKx2UwnE/0C267MVMjyNIHcSz5ZlXVDKevClFOVi+zq8OvtlZDF0KpgimmalTOWWtSEQSAUQhg==",
-      "dev": true,
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/checkbox": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/checkbox/-/checkbox-23.4.1.tgz",
-      "integrity": "sha512-wu8Zj3aO5SIRT9w/ihbw8UiEM4FP1i+vah3v+tnps1MxZizQGv9nh1Zq4i0G0Na8TCf48ydF9H+VyXakRZWoyw==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/field-base": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/checkbox-group": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/checkbox-group/-/checkbox-group-23.4.1.tgz",
-      "integrity": "sha512-zHAVbGcppTjtbdszb4hGcetn5w63ztSDGI2lirfSn9CxlnYP4TjosbBe4yDDWVPXQex0hKZekG3SF+BzD7I8kw==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/checkbox": "~23.4.1",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/field-base": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/combo-box": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/combo-box/-/combo-box-23.4.1.tgz",
-      "integrity": "sha512-TM1i0ovRxjEmKcIYrRnE9keZAxeAf224zx/StnaKsGmDt2KCaGIUtxAaoofARrhavwdi/gEr1sCs+gNXjXbNuw==",
-      "dev": true,
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/field-base": "~23.4.1",
-        "@vaadin/input-container": "~23.4.1",
-        "@vaadin/item": "~23.4.1",
-        "@vaadin/lit-renderer": "~23.4.1",
-        "@vaadin/overlay": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/component-base": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-23.4.1.tgz",
-      "integrity": "sha512-4Uf12taoxBuCIWuV0RQ/CcAvfDriOSUUD8tyNRQaNHRaxzSzsQy/Sn+8KjXVMBPSMGz0wMx74Z6vx8j4lBYOLw==",
-      "dev": true,
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-        "@vaadin/vaadin-usage-statistics": "^2.1.0",
-        "lit": "^2.0.0"
-      }
-    },
-    "@vaadin/confirm-dialog": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/confirm-dialog/-/confirm-dialog-23.4.1.tgz",
-      "integrity": "sha512-pcQ1yy1EqcE36xmpstYSNWrbxCu7FYIa9IRNieY/nFtX+8h1bvNqHGRDm2ZUfpJ5fyxp6oXsx/AMxt9QeCuVdQ==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/button": "~23.4.1",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/dialog": "~23.4.1",
-        "@vaadin/overlay": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/context-menu": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/context-menu/-/context-menu-23.4.1.tgz",
-      "integrity": "sha512-eor48ik91atC0JyI9DhN97zP1ESCh1HSqUWPVu+/NmWectq8wuRfrgromcMJrNEdoeKDbb62LCntsjxgvyTqeQ==",
-      "dev": true,
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/item": "~23.4.1",
-        "@vaadin/list-box": "~23.4.1",
-        "@vaadin/lit-renderer": "~23.4.1",
-        "@vaadin/overlay": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/custom-field": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/custom-field/-/custom-field-23.4.1.tgz",
-      "integrity": "sha512-rrHlB0+mGRozdSedgUZ9w96+Uc6dA1loTWZs+n+KZnPGZnybpWn648bGzQGbV7YMjnnc2iolMkUUdFSBB6ImMw==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/field-base": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/date-picker": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/date-picker/-/date-picker-23.4.1.tgz",
-      "integrity": "sha512-kRrhgcb1UJdSYXTGTlIhK7H7RyML+gOjLJ57l2Bn9Yi5MxmWs0VJJH1UeU+4H3R2Dgc8E+y5bguci7yW1XRZqg==",
-      "dev": true,
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.2.0",
-        "@vaadin/button": "~23.4.1",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/field-base": "~23.4.1",
-        "@vaadin/input-container": "~23.4.1",
-        "@vaadin/overlay": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/date-time-picker": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/date-time-picker/-/date-time-picker-23.4.1.tgz",
-      "integrity": "sha512-QmMv3j+EKiesDlGovAbuUrw89x75nPFPtSGZdbeM3FxPIPyGGNV7iyDBA5RwXY94sOUQRq2ktqMhy30sHZyyKA==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/custom-field": "~23.4.1",
-        "@vaadin/date-picker": "~23.4.1",
-        "@vaadin/field-base": "~23.4.1",
-        "@vaadin/time-picker": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/details": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/details/-/details-23.4.1.tgz",
-      "integrity": "sha512-r4+b64YxKW7eiV/tQyg2Ha2UmkSgtlHRX36y/QZz208CAHx7/M3uvKkeTQKMsxCmDRy8nc1LH6yHlw7l1pcTyg==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/field-base": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/dialog": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/dialog/-/dialog-23.4.1.tgz",
-      "integrity": "sha512-Ea0TCI1sBhwqLlcyG8QJ1ZZnj0Yu2i+0vPrImXdouZaq80iOO8jpQL19xGTRMjQGvir9DJKcGMAEPIBuLX2eCQ==",
-      "dev": true,
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/lit-renderer": "~23.4.1",
-        "@vaadin/overlay": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/email-field": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/email-field/-/email-field-23.4.1.tgz",
-      "integrity": "sha512-AKj7YEos+IJ8v2fyL6fNqNbXdG+HpeYOoAkjkh0nnr+JqhxbmWucEK3JQQ31F96U2SCigUNhTjfEfDp5UlKIog==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/text-field": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/field-base": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/field-base/-/field-base-23.4.1.tgz",
-      "integrity": "sha512-2kCFL/LuJRLWervC3zfZDX1T30cRILAq7wjnmQEU1C762LQ/VvARIgaiFHikugDZV2TEhWg9K1YjB4H18yaArw==",
-      "dev": true,
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "lit": "^2.0.0"
-      }
-    },
-    "@vaadin/field-highlighter": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/field-highlighter/-/field-highlighter-23.4.1.tgz",
-      "integrity": "sha512-506f3/IawEjIHqOYZe39OIbIpEwzuTsQGAY37W9sIIp/xlafLwdiSUF85tOzZC8uRb3Ns23lr8lRkyZwi7Jncw==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/overlay": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1",
-        "lit": "^2.0.0"
-      }
-    },
-    "@vaadin/form-layout": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/form-layout/-/form-layout-23.4.1.tgz",
-      "integrity": "sha512-b7mF/wBlfsudZ13abGxGrkQWmbW94RhpY6VBo4fNBo9Osz22O+waewkMkRyo5QVtrglvdvOeYInXFZrzSLYxQw==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/grid": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/grid/-/grid-23.4.1.tgz",
-      "integrity": "sha512-tBtVsf1OgibZ4vHO8+5BEyD1lHJ31tabLMHxHt2j1pVLa8NzmzcyHBXnU22mCCm8fc+fyJ2kMWJTj/2us1ZAbA==",
-      "dev": true,
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/checkbox": "~23.4.1",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/lit-renderer": "~23.4.1",
-        "@vaadin/text-field": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/horizontal-layout": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/horizontal-layout/-/horizontal-layout-23.4.1.tgz",
-      "integrity": "sha512-LbI1f2OorUAqz/98DNp/wiW8ZSdKI0jnCvRm0+NqW34KPmMKGNmZh3HtFa7Ih3fKZka8eWbEPeylhdRHb+vuzw==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/icon": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-23.4.1.tgz",
-      "integrity": "sha512-j/2c2Olg7GBEKVxhZxLR89qw8HIBKSrRUGgPA/5GxXilikOd0mZsYpHBdW8vD3hcOfd9PToMbwTSh5uhme3IaQ==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1",
-        "lit": "^2.0.0"
-      }
-    },
-    "@vaadin/icons": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/icons/-/icons-23.4.1.tgz",
-      "integrity": "sha512-CBRjD9Jvv1RJVEMn+3lKTrzJuvkmpCpJ/SwydZ980qzotHzyC052O2Pam2Bw+9LDSHisDnkvaByAz7PUKWZ7Ng==",
-      "dev": true,
-      "requires": {
-        "@polymer/iron-icon": "^3.0.0",
-        "@polymer/iron-iconset-svg": "^3.0.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/icon": "~23.4.1"
-      }
-    },
-    "@vaadin/input-container": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/input-container/-/input-container-23.4.1.tgz",
-      "integrity": "sha512-M+jLd6ftM382anu+eG/DPoUbNCEUvGwFzv6moZdv9VCwa13iKBXDuGQZ9Fe5VQ5n0+S/M6dBXBfNXuVH7onrSw==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/integer-field": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/integer-field/-/integer-field-23.4.1.tgz",
-      "integrity": "sha512-R4YvCWuJsp1oiR9NxzGMsyTJ4N1amx9tK2g7/GFwB5xsRsou3EJxxr0rl9BOQ6HYYp8QQk8Bni3cL2iYHqSTgA==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/number-field": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1"
-      }
-    },
-    "@vaadin/item": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/item/-/item-23.4.1.tgz",
-      "integrity": "sha512-hU5s4E73rafbOE9sKAoz4t9W5/bmpon0oTqjR4IItEnGCVz4ZeyAz6R0GNX3tc9NeS7a9vVwKr18NUGS8U5YRw==",
-      "dev": true,
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/list-box": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/list-box/-/list-box-23.4.1.tgz",
-      "integrity": "sha512-7xKsq1BBv9Rny/D/pss1ZULmRR/1SDdiTb8qaN+b8afzDzgKBoP5mscHXQM5LW/S20SGfdwmBEvxCkcMfoCHYg==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/item": "~23.4.1",
-        "@vaadin/vaadin-list-mixin": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/lit-renderer": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/lit-renderer/-/lit-renderer-23.4.1.tgz",
-      "integrity": "sha512-ap67s/ueZJ7VssX3vIKihjcfApD+QtZkOiUyw0GWsI7Ak+I1MY9usSUDIPRwk6Pdlm6flNuUyuAiGQstqUUJtg==",
-      "dev": true,
-      "requires": {
-        "lit": "^2.0.0"
-      }
-    },
-    "@vaadin/login": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/login/-/login-23.4.1.tgz",
-      "integrity": "sha512-Wlfc8ULmMIBdcPjYDDW3oEZoeHQW83zqpk+ZxsDNVH05iWAN4K+dCWUqlOYPr0cUbesZ8LbLlVJLlJEIiidLYg==",
-      "dev": true,
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/button": "~23.4.1",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/overlay": "~23.4.1",
-        "@vaadin/password-field": "~23.4.1",
-        "@vaadin/text-field": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/menu-bar": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/menu-bar/-/menu-bar-23.4.1.tgz",
-      "integrity": "sha512-I5Qeu2c48Y/UkYzThOb7EHpsIOzypM6XTYFt88EF2+zXGbmWS8uIeC/DQOhNlVxf9W7fwL5bkLQnb2WoXNUyLw==",
-      "dev": true,
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/button": "~23.4.1",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/context-menu": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/message-input": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/message-input/-/message-input-23.4.1.tgz",
-      "integrity": "sha512-bShy275s1lg0OXFjP+gAevYGd/x056kCVmnGYZVzILjNPLzJ0mEhSz5s50aIxsVqVtjqC8pbTs8tdgS0einReQ==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/button": "~23.4.1",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/text-area": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/message-list": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/message-list/-/message-list-23.4.1.tgz",
-      "integrity": "sha512-Qusrz3ww0wRcONIPdWtn9+dUZbD1BMpS8h55KPPkkpGAM/0BxDAimr2iYU/jnzLTNd4Vl3lxhYetpNh6kv+wzg==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/avatar": "~23.4.1",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/multi-select-combo-box": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/multi-select-combo-box/-/multi-select-combo-box-23.4.1.tgz",
-      "integrity": "sha512-De6piP0evq6k0YwyDxVyBe/wd4TVBAvat9RonT5nredBiGfXWgoPHxwVhrlSdjsfyTD4eU+amvfsJo1rnxEXtw==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/combo-box": "~23.4.1",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/field-base": "~23.4.1",
-        "@vaadin/input-container": "~23.4.1",
-        "@vaadin/lit-renderer": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/notification": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/notification/-/notification-23.4.1.tgz",
-      "integrity": "sha512-7uC4FX/5W5RPwf0GxLeZFJArxQrgl80tdwofRg6NLg0XdpYbSQoDMpJXFSFuZy5V9IsauLestgjRu08Kxeqfqw==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/lit-renderer": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1",
-        "lit": "^2.0.0"
-      }
-    },
-    "@vaadin/number-field": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/number-field/-/number-field-23.4.1.tgz",
-      "integrity": "sha512-7qm86wuavNksP7wyuoaD0/i0XbMSS61TRDmH6vmZp3zGL8L4tam7cxDeVDZkbJZ/Fjs2wmkjQjasyxu4CAo6SQ==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/field-base": "~23.4.1",
-        "@vaadin/input-container": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/overlay": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/overlay/-/overlay-23.4.1.tgz",
-      "integrity": "sha512-r4ID9ze7U67ilk1bVwAEsPmk5j4QOIXtsVl3eIdPCOKafb3yqzHn/XBLBfmhjTfAB2ZIFXZiVm7mTtNetbHQ3A==",
-      "dev": true,
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/password-field": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/password-field/-/password-field-23.4.1.tgz",
-      "integrity": "sha512-YbRfSat8g0sDdkWJvxGkHmwIjMphfPrcDk1Q07+FdN47gLLsOy7sqbXBCuHfEKloRqb3ZG524gFnLtPTAqTPoQ==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/button": "~23.4.1",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/text-field": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/polymer-legacy-adapter": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/polymer-legacy-adapter/-/polymer-legacy-adapter-23.4.1.tgz",
-      "integrity": "sha512-j5rTEvtCez2bcsoNxmA0v7OMRxWqkN95KvDeenxLYg9tpjE1FXlehVzCpdbJH3xK2yp+RJ34Us4nqUrerQgdwg==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1",
-        "lit": "^2.0.0"
-      }
-    },
-    "@vaadin/progress-bar": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/progress-bar/-/progress-bar-23.4.1.tgz",
-      "integrity": "sha512-wS3CP1aukW6z3IEG3VZQMCyN2s4qmaiLWzRUNySoqIbLVupbI7cMETVvBFf5YROf87wZGfRzw4ywSm32k7g8Yg==",
-      "dev": true,
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/radio-group": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/radio-group/-/radio-group-23.4.1.tgz",
-      "integrity": "sha512-czYxPxeZXt+RyZZyELpNLSXqfAhwhoknTupqZrTq90R58vmbN02E5L7TK/8lrypLCYR7LEHquJUHby/FUUyXtg==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/field-base": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/scroller": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/scroller/-/scroller-23.4.1.tgz",
-      "integrity": "sha512-IB4R8sypN3fHg8P3pGU/BEi0I3C4X/kBf+FoMv04DwC6uw1hKlOVUr7OZ2y2GzfVDbwnj83ur7Eo8uPh9Z3Nvw==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/select": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/select/-/select-23.4.1.tgz",
-      "integrity": "sha512-xD29xcnRDqb28cnHCuDhNME3ELx0bWqSDnI2K+HG+MiN/B70G04TjN4ShmuHIp5Ehc4BA7+xTQUobCmxB/wmog==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.2.0",
-        "@vaadin/button": "~23.4.1",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/field-base": "~23.4.1",
-        "@vaadin/input-container": "~23.4.1",
-        "@vaadin/item": "~23.4.1",
-        "@vaadin/list-box": "~23.4.1",
-        "@vaadin/lit-renderer": "~23.4.1",
-        "@vaadin/overlay": "~23.4.1",
-        "@vaadin/vaadin-list-mixin": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/split-layout": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/split-layout/-/split-layout-23.4.1.tgz",
-      "integrity": "sha512-je++EUkImhCU6fUYiCNJ9qK0oJaraKujUDxf/VqQB2icaaxEKjpvvMkkD47JJTXETjoOBFIRFWdyoQRimQXvhw==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/tabs": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/tabs/-/tabs-23.4.1.tgz",
-      "integrity": "sha512-8K7LwcSSCiLPsCwC56fU7uiEoZ3tetmomllTmL8ShKXZ1XPUYU6QuslmoTtmWgh2OcBatJ8DTeitiidAMx8Dqg==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/item": "~23.4.1",
-        "@vaadin/vaadin-list-mixin": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/tabsheet": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/tabsheet/-/tabsheet-23.4.1.tgz",
-      "integrity": "sha512-S9zbf8FLyehICdC9QGhc6M3bTZYVZ93R9krugnULlAe+JHWgFEuXF18JLzqvVN8Hn37aW5sPBdSZKaqD04xh2g==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/field-base": "~23.4.1",
-        "@vaadin/scroller": "~23.4.1",
-        "@vaadin/tabs": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/testing-helpers": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@vaadin/testing-helpers/-/testing-helpers-0.5.0.tgz",
-      "integrity": "sha512-JJlqWzMhH6tEwEpEBhzJgdS1Eujqg5Yt3ZRrTPVKLQqRR+EtnKFiYC4MoyAejQASUjBtbQgOE5KLi7ajbCWFzA==",
-      "dev": true,
-      "requires": {
-        "@esm-bundle/chai": "^4.3.1",
-        "@open-wc/semantic-dom-diff": "^0.19.7",
-        "@polymer/polymer": "^3.5.1",
-        "lit": "^2.6.1",
-        "sinon-chai": "3.7.0"
-      }
-    },
-    "@vaadin/text-area": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/text-area/-/text-area-23.4.1.tgz",
-      "integrity": "sha512-ofNTDbRsh/K2zM7WtosWDS2yTnsTz19CYcYZ096D5N5PUPTXxotZ+TDUAiwdVqNeN1un6Xx1GeUBKOgzqECwwA==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/field-base": "~23.4.1",
-        "@vaadin/input-container": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/text-field": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/text-field/-/text-field-23.4.1.tgz",
-      "integrity": "sha512-QCq4EP/1wToM2vwS35k+aia3RCZuzDJc/OK7vtBlkZDH3qGEWNLDdjtlbKqM973jyP7fJWKuN0mGtp+2pbVN5Q==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/field-base": "~23.4.1",
-        "@vaadin/input-container": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/time-picker": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/time-picker/-/time-picker-23.4.1.tgz",
-      "integrity": "sha512-qNNpG4xyLhJh2fxSM2XrNEG5/zZRdXTffV4D2mUAy0PGu1A81nwOOOS7Dfd6jzwCSN2GZOYtLUEzdtuumKvIlw==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/combo-box": "~23.4.1",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/field-base": "~23.4.1",
-        "@vaadin/input-container": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/tooltip": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/tooltip/-/tooltip-23.4.1.tgz",
-      "integrity": "sha512-V7xQlJET/2Y+OHXdKH9O1eWGZ5g2Dy99wtP+oFafxxbmCiXbBlGvF3ytsM9/fKl+5Y1unyWVRtH3nuNlQtJzGA==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/overlay": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/upload": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/upload/-/upload-23.4.1.tgz",
-      "integrity": "sha512-GwjaAn/9TVnFXW7MzMZ/NbZ8KUb1LAydLvwW9qCsA0N9vJORDYiMsozd1jXSVV+n4hhblMWdptYaMhqDD4b2wg==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/button": "~23.4.1",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/progress-bar": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/vaadin-development-mode-detector": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-development-mode-detector/-/vaadin-development-mode-detector-2.0.7.tgz",
-      "integrity": "sha512-9FhVhr0ynSR3X2ao+vaIEttcNU5XfzCbxtmYOV8uIRnUCtNgbvMOIcyGBvntsX9I5kvIP2dV3cFAOG9SILJzEA=="
-    },
-    "@vaadin/vaadin-list-mixin": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-list-mixin/-/vaadin-list-mixin-23.4.1.tgz",
-      "integrity": "sha512-mCU0LWZRRXMcSweJVFk1VVrsUDCchZGlKhGMsf6scLviAPbkL2A1Nn8KC3tGEnnQysNQu3+EfGmvy9AIBtpymg==",
-      "dev": true,
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1"
-      }
-    },
-    "@vaadin/vaadin-lumo-styles": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-23.4.1.tgz",
-      "integrity": "sha512-2zhuMBRpk56Bz9p1kWM9mS0M8tHcIDN3yKQFKmkGEanCJoOOQ4PC9PuEUM6X/kcNXEIpfwiriFzjTBLgZDtVUQ==",
-      "dev": true,
-      "requires": {
-        "@polymer/iron-icon": "^3.0.0",
-        "@polymer/iron-iconset-svg": "^3.0.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/icon": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/vaadin-material-styles": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-23.4.1.tgz",
-      "integrity": "sha512-nzdt4hY/JRuBssoMLi7GFZwCmNKZfqf8bxp3XA8dCvrb9wBzYlCVmY6YJXvH1L7Nw+qGtkMV/zJHdM9jwIPZsw==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/vaadin-themable-mixin": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-23.4.1.tgz",
-      "integrity": "sha512-MWIsdtYTUD7mun1I93S2akmsUAtDrx8ZJlpjpTC148/2QxDQOFoHmL0OdeDLJRljZG4cZU3hmAuOpnjDC35rKg==",
-      "dev": true,
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "lit": "^2.0.0"
-      }
-    },
-    "@vaadin/vaadin-usage-statistics": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.1.2.tgz",
-      "integrity": "sha512-xKs1PvRfTXsG0eWWcImLXWjv7D+f1vfoIvovppv6pZ5QX8xgcxWUdNgERlOOdGt3CTuxQXukTBW3+Qfva+OXSg==",
-      "requires": {
-        "@vaadin/vaadin-development-mode-detector": "^2.0.0"
-      }
-    },
-    "@vaadin/vertical-layout": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/vertical-layout/-/vertical-layout-23.4.1.tgz",
-      "integrity": "sha512-wDVzT1pVqgxQCRAPui+0IwGdVW/vU2+cmEtOZQat2juMLhH0s+DPNz37yy00TCIH3N5Um4TzihhCVtD96qsY5Q==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@vaadin/virtual-list": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/virtual-list/-/virtual-list-23.4.1.tgz",
-      "integrity": "sha512-TZLbMVxwTIgJl16rsEKIXRRzfByOzIQkZ1n1IVkcru+V3DaEFyPE2GWJR4m+kSP+gDHAddaHzkEfZyzuv6kq9g==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~23.4.1",
-        "@vaadin/lit-renderer": "~23.4.1",
-        "@vaadin/vaadin-lumo-styles": "~23.4.1",
-        "@vaadin/vaadin-material-styles": "~23.4.1",
-        "@vaadin/vaadin-themable-mixin": "~23.4.1"
-      }
-    },
-    "@wdio/config": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.37.0.tgz",
-      "integrity": "sha512-1zNWhZY+z8rTQorXOZmpGE/rjE7wt2up8z0VQNupRQMhhDk5y9JgOgRRNTwLfcNv5HYRbj0LnChHh/4EGc5Nfw==",
-      "dev": true,
-      "requires": {
-        "@wdio/logger": "8.28.0",
-        "@wdio/types": "8.37.0",
-        "@wdio/utils": "8.37.0",
-        "decamelize": "^6.0.0",
-        "deepmerge-ts": "^5.0.0",
-        "glob": "^10.2.2",
-        "import-meta-resolve": "^4.0.0"
-      }
-    },
-    "@wdio/logger": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-8.28.0.tgz",
-      "integrity": "sha512-/s6zNCqwy1hoc+K4SJypis0Ud0dlJ+urOelJFO1x0G0rwDRWyFiUP6ijTaCcFxAm29jYEcEPWijl2xkVIHwOyA==",
-      "dev": true,
-      "requires": {
-        "chalk": "^5.1.2",
-        "loglevel": "^1.6.0",
-        "loglevel-plugin-prefix": "^0.8.4",
-        "strip-ansi": "^7.1.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-          "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-          "dev": true
-        }
-      }
-    },
-    "@wdio/protocols": {
-      "version": "8.32.0",
-      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-8.32.0.tgz",
-      "integrity": "sha512-inLJRrtIGdTz/YPbcsvpSvPlYQFTVtF3OYBwAXhG2FiP1ZwE1CQNLP/xgRGye1ymdGCypGkexRqIx3KBGm801Q==",
-      "dev": true
-    },
-    "@wdio/repl": {
-      "version": "8.24.12",
-      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-8.24.12.tgz",
-      "integrity": "sha512-321F3sWafnlw93uRTSjEBVuvWCxTkWNDs7ektQS15drrroL3TMeFOynu4rDrIz0jXD9Vas0HCD2Tq/P0uxFLdw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "^20.1.0"
-      }
-    },
-    "@wdio/types": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.37.0.tgz",
-      "integrity": "sha512-36kmSlZcVhsMlbhaSCQUfL51iG81FlbzW4Dfkz4903cDkxmh64bgxydZbRB5aPLnJzzR7tI3chIME8zSVZFR8w==",
-      "dev": true,
-      "requires": {
-        "@types/node": "^20.1.0"
-      }
-    },
-    "@wdio/utils": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.37.0.tgz",
-      "integrity": "sha512-2YtT8fH8mfMuDeEXKtFgxxBBoIGezSKysKAydtV9sICg4ZJM5CSsSzhfGaszC2qgOv3WHaBsfgg0Nljp1g2Y5A==",
-      "dev": true,
-      "requires": {
-        "@puppeteer/browsers": "^1.6.0",
-        "@wdio/logger": "8.28.0",
-        "@wdio/types": "8.37.0",
-        "decamelize": "^6.0.0",
-        "deepmerge-ts": "^5.1.0",
-        "edgedriver": "^5.3.5",
-        "geckodriver": "^4.3.1",
-        "get-port": "^7.0.0",
-        "import-meta-resolve": "^4.0.0",
-        "locate-app": "^2.1.0",
-        "safaridriver": "^0.1.0",
-        "split2": "^4.2.0",
-        "wait-port": "^1.0.4"
-      },
-      "dependencies": {
-        "@puppeteer/browsers": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
-          "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
-          "dev": true,
-          "requires": {
-            "debug": "4.3.4",
-            "extract-zip": "2.0.1",
-            "progress": "2.0.3",
-            "proxy-agent": "6.3.1",
-            "tar-fs": "3.0.4",
-            "unbzip2-stream": "1.4.3",
-            "yargs": "17.7.2"
-          }
-        },
-        "lru-cache": {
-          "version": "7.18.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-          "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-          "dev": true
-        },
-        "proxy-agent": {
-          "version": "6.3.1",
-          "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
-          "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
-          "dev": true,
-          "requires": {
-            "agent-base": "^7.0.2",
-            "debug": "^4.3.4",
-            "http-proxy-agent": "^7.0.0",
-            "https-proxy-agent": "^7.0.2",
-            "lru-cache": "^7.14.1",
-            "pac-proxy-agent": "^7.0.1",
-            "proxy-from-env": "^1.1.0",
-            "socks-proxy-agent": "^8.0.2"
-          }
-        },
-        "tar-fs": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
-          "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
-          "dev": true,
-          "requires": {
-            "mkdirp-classic": "^0.5.2",
-            "pump": "^3.0.0",
-            "tar-stream": "^3.1.5"
-          }
-        },
-        "tar-stream": {
-          "version": "3.1.7",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-          "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
-          "dev": true,
-          "requires": {
-            "b4a": "^1.6.4",
-            "fast-fifo": "^1.2.0",
-            "streamx": "^2.15.0"
-          }
-        }
-      }
-    },
-    "@web/browser-logs": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@web/browser-logs/-/browser-logs-0.4.0.tgz",
-      "integrity": "sha512-/EBiDAUCJ2DzZhaFxTPRIznEPeafdLbXShIL6aTu7x73x7ZoxSDv7DGuTsh2rWNMUa4+AKli4UORrpyv6QBOiA==",
-      "dev": true,
-      "requires": {
-        "errorstacks": "^2.2.0"
-      }
-    },
-    "@web/config-loader": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@web/config-loader/-/config-loader-0.3.1.tgz",
-      "integrity": "sha512-IYjHXUgSGGNpO3YJQ9foLcazbJlAWDdJGRe9be7aOhon0Nd6Na5JIOJAej7jsMu76fKHr4b4w2LfIdNQ4fJ8pA==",
-      "dev": true
-    },
-    "@web/dev-server": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@web/dev-server/-/dev-server-0.4.5.tgz",
-      "integrity": "sha512-R11sODOLFcm51f2uir51KE4QXRSYakDaeBeJdrUutPCmYUDEk86GjYBR3R1wslimnwGPIjhFDsXNMfASxYfgAQ==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.12.11",
-        "@types/command-line-args": "^5.0.0",
-        "@web/config-loader": "^0.3.0",
-        "@web/dev-server-core": "^0.7.2",
-        "@web/dev-server-rollup": "^0.6.1",
-        "camelcase": "^6.2.0",
-        "command-line-args": "^5.1.1",
-        "command-line-usage": "^7.0.1",
-        "debounce": "^1.2.0",
-        "deepmerge": "^4.2.2",
-        "ip": "^2.0.1",
-        "nanocolors": "^0.2.1",
-        "open": "^8.0.2",
-        "portfinder": "^1.0.32"
-      }
-    },
-    "@web/dev-server-core": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@web/dev-server-core/-/dev-server-core-0.7.2.tgz",
-      "integrity": "sha512-Q/0jpF13Ipk+qGGQ+Yx/FW1TQBYazpkfgYHHo96HBE7qv4V4KKHqHglZcSUxti/zd4bToxX1cFTz8dmbTlb8JA==",
-      "dev": true,
-      "requires": {
-        "@types/koa": "^2.11.6",
-        "@types/ws": "^7.4.0",
-        "@web/parse5-utils": "^2.1.0",
-        "chokidar": "^3.4.3",
-        "clone": "^2.1.2",
-        "es-module-lexer": "^1.0.0",
-        "get-stream": "^6.0.0",
-        "is-stream": "^2.0.0",
-        "isbinaryfile": "^5.0.0",
-        "koa": "^2.13.0",
-        "koa-etag": "^4.0.0",
-        "koa-send": "^5.0.1",
-        "koa-static": "^5.0.0",
-        "lru-cache": "^8.0.4",
-        "mime-types": "^2.1.27",
-        "parse5": "^6.0.1",
-        "picomatch": "^2.2.2",
-        "ws": "^7.4.2"
-      }
-    },
-    "@web/dev-server-esbuild": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@web/dev-server-esbuild/-/dev-server-esbuild-1.0.2.tgz",
-      "integrity": "sha512-ak5mKt7L0H/Fa470Ku7p9A1eI32DNyFGM83jDkJviBO8r3lM00O5hVFW1K+UIYNC5EyanLyPxTqgtIuQEyMYcQ==",
-      "dev": true,
-      "requires": {
-        "@mdn/browser-compat-data": "^4.0.0",
-        "@web/dev-server-core": "^0.7.0",
-        "esbuild": "^0.19.11",
-        "get-tsconfig": "^4.7.2",
-        "parse5": "^6.0.1",
-        "ua-parser-js": "^1.0.33"
-      }
-    },
-    "@web/dev-server-rollup": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@web/dev-server-rollup/-/dev-server-rollup-0.6.3.tgz",
-      "integrity": "sha512-dzMwQRBk9Rhpfoo7vvQGvRP18sDELejJCwxsMdt509aLouIB6fviv0i87DJQWbXH24hBeq6+jSILI3JTtVaPZQ==",
-      "dev": true,
-      "requires": {
-        "@rollup/plugin-node-resolve": "^15.0.1",
-        "@web/dev-server-core": "^0.7.2",
-        "nanocolors": "^0.2.1",
-        "parse5": "^6.0.1",
-        "rollup": "^4.4.0",
-        "whatwg-url": "^11.0.0"
-      }
-    },
-    "@web/parse5-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@web/parse5-utils/-/parse5-utils-2.1.0.tgz",
-      "integrity": "sha512-GzfK5disEJ6wEjoPwx8AVNwUe9gYIiwc+x//QYxYDAFKUp4Xb1OJAGLc2l2gVrSQmtPGLKrTRcW90Hv4pEq1qA==",
-      "dev": true,
-      "requires": {
-        "@types/parse5": "^6.0.1",
-        "parse5": "^6.0.1"
-      }
-    },
-    "@web/rollup-plugin-html": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@web/rollup-plugin-html/-/rollup-plugin-html-2.3.0.tgz",
-      "integrity": "sha512-ap4AisBacK6WwrTnVlPErupxlywWU1ELsjGIMZ4VpofvhbVTBIGErJo5VEj2mSJyEH3I1EbzUcWuhDCePrnWEw==",
-      "dev": true,
-      "requires": {
-        "@web/parse5-utils": "^2.1.0",
-        "glob": "^10.0.0",
-        "html-minifier-terser": "^7.1.0",
-        "lightningcss": "^1.24.0",
-        "parse5": "^6.0.1",
-        "picomatch": "^2.2.2"
-      }
-    },
-    "@web/test-runner": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/@web/test-runner/-/test-runner-0.18.2.tgz",
-      "integrity": "sha512-jA+957ic31aG/f1mr1b+HYzf/uTu4QsvFhyVgTKi2s5YQYGBbtfzx9PnYi47MVC9K9OHRbW8cq2Urds9qwSU3w==",
-      "dev": true,
-      "requires": {
-        "@web/browser-logs": "^0.4.0",
-        "@web/config-loader": "^0.3.0",
-        "@web/dev-server": "^0.4.0",
-        "@web/test-runner-chrome": "^0.16.0",
-        "@web/test-runner-commands": "^0.9.0",
-        "@web/test-runner-core": "^0.13.0",
-        "@web/test-runner-mocha": "^0.9.0",
-        "camelcase": "^6.2.0",
-        "command-line-args": "^5.1.1",
-        "command-line-usage": "^7.0.1",
-        "convert-source-map": "^2.0.0",
-        "diff": "^5.0.0",
-        "globby": "^11.0.1",
-        "nanocolors": "^0.2.1",
-        "portfinder": "^1.0.32",
-        "source-map": "^0.7.3"
-      }
-    },
-    "@web/test-runner-chrome": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-chrome/-/test-runner-chrome-0.16.0.tgz",
-      "integrity": "sha512-Edc6Y49aVB6k18S5IOj9OCX3rEf8F3jptIu0p95+imqxmcutFEh1GNmlAk2bQGnXS0U6uVY7Xbf61fiaXUQqhg==",
-      "dev": true,
-      "requires": {
-        "@web/test-runner-core": "^0.13.0",
-        "@web/test-runner-coverage-v8": "^0.8.0",
-        "async-mutex": "0.4.0",
-        "chrome-launcher": "^0.15.0",
-        "puppeteer-core": "^22.0.0"
-      }
-    },
-    "@web/test-runner-commands": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-commands/-/test-runner-commands-0.9.0.tgz",
-      "integrity": "sha512-zeLI6QdH0jzzJMDV5O42Pd8WLJtYqovgdt0JdytgHc0d1EpzXDsc7NTCJSImboc2NcayIsWAvvGGeRF69SMMYg==",
-      "dev": true,
-      "requires": {
-        "@web/test-runner-core": "^0.13.0",
-        "mkdirp": "^1.0.4"
-      }
-    },
-    "@web/test-runner-core": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-core/-/test-runner-core-0.13.3.tgz",
-      "integrity": "sha512-ilDqF/v2sj0sD69FNSIDT7uw4M1yTVedLBt32/lXy3MMi6suCM7m/ZlhsBy8PXhf879WMvzBOl/vhJBpEMB9vA==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.12.11",
-        "@types/babel__code-frame": "^7.0.2",
-        "@types/co-body": "^6.1.0",
-        "@types/convert-source-map": "^2.0.0",
-        "@types/debounce": "^1.2.0",
-        "@types/istanbul-lib-coverage": "^2.0.3",
-        "@types/istanbul-reports": "^3.0.0",
-        "@web/browser-logs": "^0.4.0",
-        "@web/dev-server-core": "^0.7.2",
-        "chokidar": "^3.4.3",
-        "cli-cursor": "^3.1.0",
-        "co-body": "^6.1.0",
-        "convert-source-map": "^2.0.0",
-        "debounce": "^1.2.0",
-        "dependency-graph": "^0.11.0",
-        "globby": "^11.0.1",
-        "internal-ip": "^6.2.0",
-        "istanbul-lib-coverage": "^3.0.0",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.0.2",
-        "log-update": "^4.0.0",
-        "nanocolors": "^0.2.1",
-        "nanoid": "^3.1.25",
-        "open": "^8.0.2",
-        "picomatch": "^2.2.2",
-        "source-map": "^0.7.3"
-      }
-    },
-    "@web/test-runner-coverage-v8": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-coverage-v8/-/test-runner-coverage-v8-0.8.0.tgz",
-      "integrity": "sha512-PskiucYpjUtgNfR2zF2AWqWwjXL7H3WW/SnCAYmzUrtob7X9o/+BjdyZ4wKbOxWWSbJO4lEdGIDLu+8X2Xw+lA==",
-      "dev": true,
-      "requires": {
-        "@web/test-runner-core": "^0.13.0",
-        "istanbul-lib-coverage": "^3.0.0",
-        "lru-cache": "^8.0.4",
-        "picomatch": "^2.2.2",
-        "v8-to-istanbul": "^9.0.1"
-      }
-    },
-    "@web/test-runner-mocha": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-mocha/-/test-runner-mocha-0.9.0.tgz",
-      "integrity": "sha512-ZL9F6FXd0DBQvo/h/+mSfzFTSRVxzV9st/AHhpgABtUtV/AIpVE9to6+xdkpu6827kwjezdpuadPfg+PlrBWqQ==",
-      "dev": true,
-      "requires": {
-        "@web/test-runner-core": "^0.13.0"
-      }
-    },
-    "@web/test-runner-playwright": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-playwright/-/test-runner-playwright-0.11.0.tgz",
-      "integrity": "sha512-s+f43DSAcssKYVOD9SuzueUcctJdHzq1by45gAnSCKa9FQcaTbuYe8CzmxA21g+NcL5+ayo4z+MA9PO4H+PssQ==",
-      "dev": true,
-      "requires": {
-        "@web/test-runner-core": "^0.13.0",
-        "@web/test-runner-coverage-v8": "^0.8.0",
-        "playwright": "^1.22.2"
-      }
-    },
-    "@web/test-runner-saucelabs": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-saucelabs/-/test-runner-saucelabs-0.11.1.tgz",
-      "integrity": "sha512-iA6DgkAT0ed15CtLqjYoGusOJiRvmjGbz4oorv+YvYRzwjCqxrf2H19PNxEf96fj2JMEgN6TApFrvcZGBBajiw==",
-      "dev": true,
-      "requires": {
-        "@web/test-runner-webdriver": "^0.8.0",
-        "ip": "^2.0.1",
-        "nanoid": "^3.1.25",
-        "saucelabs": "^7.2.0",
-        "webdriver": "^8.8.6",
-        "webdriverio": "^8.8.6"
-      }
-    },
-    "@web/test-runner-visual-regression": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-visual-regression/-/test-runner-visual-regression-0.9.0.tgz",
-      "integrity": "sha512-06M1WffLy+BJo08s57RumKYUULD/UB8u7DgZ8/MJZYCt+7r4Vt54w34CwSGHCpeDLY8Z/YkxecafvzDjuLnEJQ==",
-      "dev": true,
-      "requires": {
-        "@types/mkdirp": "^1.0.1",
-        "@types/pixelmatch": "^5.2.2",
-        "@types/pngjs": "^6.0.0",
-        "@web/test-runner-commands": "^0.9.0",
-        "@web/test-runner-core": "^0.13.0",
-        "mkdirp": "^1.0.4",
-        "pixelmatch": "^5.2.1",
-        "pngjs": "^7.0.0"
-      }
-    },
-    "@web/test-runner-webdriver": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-webdriver/-/test-runner-webdriver-0.8.0.tgz",
-      "integrity": "sha512-Ps+xJeHSh8uvTTRcSOTsDFPEVTjP0oW7r8XVc3wXP9qBmCOsTWyQhDALsYqWwT0FwHr9UV2iRiiSZK8FPBRHjg==",
-      "dev": true,
-      "requires": {
-        "@web/test-runner-core": "^0.13.0",
-        "webdriverio": "^8.8.6"
-      }
-    },
-    "@webcomponents/shadycss": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.11.2.tgz",
-      "integrity": "sha512-vRq+GniJAYSBmTRnhCYPAPq6THYqovJ/gzGThWbgEZUQaBccndGTi1hdiUP15HzEco0I6t4RCtXyX0rsSmwgPw=="
-    },
-    "abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
-      "requires": {
-        "event-target-shim": "^5.0.0"
-      }
-    },
-    "accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "dev": true,
-      "requires": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
-      }
-    },
-    "acorn": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-      "dev": true
-    },
-    "agent-base": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.3.4"
-      }
-    },
-    "ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "dev": true,
-      "requires": {
-        "type-fest": "^0.21.3"
-      }
-    },
-    "ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true
-    },
-    "ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "requires": {
-        "color-convert": "^1.9.0"
-      }
-    },
-    "anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
-      "requires": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      }
-    },
-    "archiver": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
-      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
-      "dev": true,
-      "requires": {
-        "archiver-utils": "^5.0.2",
-        "async": "^3.2.4",
-        "buffer-crc32": "^1.0.0",
-        "readable-stream": "^4.0.0",
-        "readdir-glob": "^1.1.2",
-        "tar-stream": "^3.0.0",
-        "zip-stream": "^6.0.1"
-      },
-      "dependencies": {
-        "async": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-          "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-          "dev": true
-        },
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
-        "buffer-crc32": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
-          "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "4.5.2",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-          "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-          "dev": true,
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^6.0.3",
-            "events": "^3.3.0",
-            "process": "^0.11.10",
-            "string_decoder": "^1.3.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
-        },
-        "tar-stream": {
-          "version": "3.1.7",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-          "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
-          "dev": true,
-          "requires": {
-            "b4a": "^1.6.4",
-            "fast-fifo": "^1.2.0",
-            "streamx": "^2.15.0"
-          }
-        }
-      }
-    },
-    "archiver-utils": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
-      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
-      "dev": true,
-      "requires": {
-        "glob": "^10.0.0",
-        "graceful-fs": "^4.2.0",
-        "is-stream": "^2.0.1",
-        "lazystream": "^1.0.0",
-        "lodash": "^4.17.15",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
-        "readable-stream": {
-          "version": "4.5.2",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-          "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-          "dev": true,
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^6.0.3",
-            "events": "^3.3.0",
-            "process": "^0.11.10",
-            "string_decoder": "^1.3.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
-        }
-      }
-    },
-    "aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dev": true,
-      "requires": {
-        "dequal": "^2.0.3"
-      }
-    },
-    "array-back": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-      "dev": true
-    },
-    "array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true
-    },
-    "assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true,
-      "peer": true
-    },
-    "ast-types": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.0.1"
-      }
-    },
-    "astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true
-    },
-    "async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.14"
-      }
-    },
-    "async-mutex": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
-      "integrity": "sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
-    },
-    "b4a": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
-      "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==",
-      "dev": true
-    },
-    "balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
-    "bare-events": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.2.2.tgz",
-      "integrity": "sha512-h7z00dWdG0PYOQEvChhOSWvOfkIKsdZGkWr083FgN/HyoQuebSew/cgirYqh9SCuy/hRvxc5Vy6Fw8xAmYHLkQ==",
-      "dev": true,
-      "optional": true
-    },
-    "bare-fs": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.0.tgz",
-      "integrity": "sha512-TNFqa1B4N99pds2a5NYHR15o0ZpdNKbAeKTE/+G6ED/UeOavv8RY3dr/Fu99HW3zU3pXpo2kDNO8Sjsm2esfOw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "bare-events": "^2.0.0",
-        "bare-path": "^2.0.0",
-        "bare-stream": "^1.0.0"
-      }
-    },
-    "bare-os": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.3.0.tgz",
-      "integrity": "sha512-oPb8oMM1xZbhRQBngTgpcQ5gXw6kjOaRsSWsIeNyRxGed2w/ARyP7ScBYpWR1qfX2E5rS3gBw6OWcSQo+s+kUg==",
-      "dev": true,
-      "optional": true
-    },
-    "bare-path": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.3.tgz",
-      "integrity": "sha512-lh/eITfU8hrj9Ru5quUp0Io1kJWIk1bTjzo7JH1P5dWmQ2EL4hFUlfI8FonAhSlgIfhn63p84CDY/x+PisgcXA==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "bare-os": "^2.1.0"
-      }
-    },
-    "bare-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-1.0.0.tgz",
-      "integrity": "sha512-KhNUoDL40iP4gFaLSsoGE479t0jHijfYdIcxRn/XtezA2BaUD0NRf/JGRpsMq6dMNM+SrCrB0YSSo/5wBY4rOQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "streamx": "^2.16.1"
-      }
-    },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
-    },
-    "basic-ftp": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
-      "dev": true
-    },
-    "big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "dev": true
-    },
-    "binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true
-    },
-    "bl": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
-      "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
-      "dev": true,
-      "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "bluebird": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
-      "dev": true
-    },
-    "brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "requires": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
-      "requires": {
-        "fill-range": "^7.1.1"
-      }
-    },
-    "buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
-    "buffer-alloc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-      "dev": true,
-      "requires": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
-      }
-    },
-    "buffer-alloc-unsafe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-      "dev": true
-    },
-    "buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true
-    },
-    "buffer-fill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
-      "dev": true
-    },
-    "buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
-    },
-    "builtin-modules": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
-      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
-      "dev": true
-    },
-    "bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "dev": true
-    },
-    "cache-content-type": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cache-content-type/-/cache-content-type-1.0.1.tgz",
-      "integrity": "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==",
-      "dev": true,
-      "requires": {
-        "mime-types": "^2.1.18",
-        "ylru": "^1.2.0"
-      }
-    },
-    "cacheable-lookup": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
-      "dev": true
-    },
-    "cacheable-request": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
-      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
-      "dev": true,
-      "requires": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^4.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^6.0.1",
-        "responselike": "^2.0.0"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        }
-      }
-    },
-    "call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
-      "dev": true,
-      "requires": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
-      }
-    },
-    "camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dev": true,
-      "requires": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "dev": true
-    },
-    "capital-case": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
-      "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
-      "dev": true,
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
-    },
-    "chai": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
-      "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.8"
-      }
-    },
-    "chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      }
-    },
-    "chalk-template": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
-      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
-      "dev": true,
-      "requires": {
-        "chalk": "^4.1.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
-    "change-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
-      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-      "dev": true,
-      "requires": {
-        "camel-case": "^4.1.2",
-        "capital-case": "^1.0.4",
-        "constant-case": "^3.0.4",
-        "dot-case": "^3.0.4",
-        "header-case": "^2.0.4",
-        "no-case": "^3.0.4",
-        "param-case": "^3.0.4",
-        "pascal-case": "^3.1.2",
-        "path-case": "^3.0.4",
-        "sentence-case": "^3.0.4",
-        "snake-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "check-error": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "get-func-name": "^2.0.2"
-      }
-    },
-    "chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "requires": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      }
-    },
-    "chrome-launcher": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.2.tgz",
-      "integrity": "sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "escape-string-regexp": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "lighthouse-logger": "^1.0.0"
-      },
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-          "dev": true
-        }
-      }
-    },
-    "chromium-bidi": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.3.tgz",
-      "integrity": "sha512-qXlsCmpCZJAnoTYI83Iu6EdYQpMYdVkCfq08KDh2pmlVqK5t5IA9mGs4/LwCwp4fqisSOMXZxP3HIh8w8aRn0A==",
-      "dev": true,
-      "requires": {
-        "mitt": "3.0.1",
-        "urlpattern-polyfill": "10.0.0",
-        "zod": "3.23.8"
-      }
-    },
-    "clean-css": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
-      "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
-      "dev": true,
-      "requires": {
-        "source-map": "~0.6.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
-    "cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
-      "requires": {
-        "restore-cursor": "^3.1.0"
-      }
-    },
-    "cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "requires": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        },
-        "wrap-ansi": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        }
-      }
-    },
-    "clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "dev": true
-    },
-    "clone-response": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
-      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
-      "dev": true,
-      "requires": {
-        "mimic-response": "^1.0.0"
-      }
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
-      "dev": true
-    },
-    "co-body": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/co-body/-/co-body-6.1.0.tgz",
-      "integrity": "sha512-m7pOT6CdLN7FuXUcpuz/8lfQ/L77x8SchHCF4G0RBTJO20Wzmhn5Sp4/5WsKy8OSpifBSUrmg83qEqaDHdyFuQ==",
-      "dev": true,
-      "requires": {
-        "inflation": "^2.0.0",
-        "qs": "^6.5.2",
-        "raw-body": "^2.3.3",
-        "type-is": "^1.6.16"
-      }
-    },
-    "color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "requires": {
-        "color-name": "1.1.3"
-      }
-    },
-    "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
-    "command-line-args": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
-      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
-      "dev": true,
-      "requires": {
-        "array-back": "^3.1.0",
-        "find-replace": "^3.0.0",
-        "lodash.camelcase": "^4.3.0",
-        "typical": "^4.0.0"
-      }
-    },
-    "command-line-usage": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.1.tgz",
-      "integrity": "sha512-NCyznE//MuTjwi3y84QVUGEOT+P5oto1e1Pk/jFPVdPPfsG03qpTIl3yw6etR+v73d0lXsoojRpvbru2sqePxQ==",
-      "dev": true,
-      "requires": {
-        "array-back": "^6.2.2",
-        "chalk-template": "^0.4.0",
-        "table-layout": "^3.0.0",
-        "typical": "^7.1.1"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "6.2.2",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
-          "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
-          "dev": true
-        },
-        "typical": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/typical/-/typical-7.1.1.tgz",
-          "integrity": "sha512-T+tKVNs6Wu7IWiAce5BgMd7OZfNYUndHwc5MknN+UHOudi7sGZzuHdCadllRuqJ3fPtgFtIH9+lt9qRv6lmpfA==",
-          "dev": true
-        }
-      }
-    },
-    "commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "dev": true
-    },
-    "compress-commons": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
-      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
-      "dev": true,
-      "requires": {
-        "crc-32": "^1.2.0",
-        "crc32-stream": "^6.0.0",
-        "is-stream": "^2.0.1",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
-        "readable-stream": {
-          "version": "4.5.2",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-          "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-          "dev": true,
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^6.0.3",
-            "events": "^3.3.0",
-            "process": "^0.11.10",
-            "string_decoder": "^1.3.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
-        }
-      }
-    },
-    "compressing": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/compressing/-/compressing-1.10.1.tgz",
-      "integrity": "sha512-XXwUffcVjqv8NGSQu1ttp6eMmuZ3zZEAec28Rt30o/vkXE20jXhowRQ9LXLY4uOgFkxXrNzApLobpam53Dc1AA==",
-      "dev": true,
-      "requires": {
-        "@eggjs/yauzl": "^2.11.0",
-        "flushwritable": "^1.0.0",
-        "get-ready": "^1.0.0",
-        "iconv-lite": "^0.5.0",
-        "mkdirp": "^0.5.1",
-        "pump": "^3.0.0",
-        "streamifier": "^0.1.1",
-        "tar-stream": "^1.5.2",
-        "yazl": "^2.4.2"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.2.tgz",
-          "integrity": "sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==",
-          "dev": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.6"
-          }
-        }
-      }
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
-    },
-    "constant-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
-      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-      "dev": true,
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case": "^2.0.2"
-      }
-    },
-    "content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.2.1"
-      }
-    },
-    "content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "dev": true
-    },
-    "convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true
-    },
-    "cookies": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
-      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
-      "dev": true,
-      "requires": {
-        "depd": "~2.0.0",
-        "keygrip": "~1.1.0"
-      }
-    },
-    "core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
-    },
-    "crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "dev": true
-    },
-    "crc32-stream": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
-      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
-      "dev": true,
-      "requires": {
-        "crc-32": "^1.2.0",
-        "readable-stream": "^4.0.0"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
-        "readable-stream": {
-          "version": "4.5.2",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-          "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-          "dev": true,
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^6.0.3",
-            "events": "^3.3.0",
-            "process": "^0.11.10",
-            "string_decoder": "^1.3.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
-        }
-      }
-    },
-    "cross-fetch": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
-      "dev": true,
-      "requires": {
-        "node-fetch": "^2.6.12"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-          "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-          "dev": true,
-          "requires": {
-            "whatwg-url": "^5.0.0"
-          }
-        },
-        "tr46": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-          "dev": true
-        },
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-          "dev": true
-        },
-        "whatwg-url": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-          "dev": true,
-          "requires": {
-            "tr46": "~0.0.3",
-            "webidl-conversions": "^3.0.0"
-          }
-        }
-      }
-    },
-    "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
-      "requires": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      }
-    },
-    "css-shorthand-properties": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/css-shorthand-properties/-/css-shorthand-properties-1.1.1.tgz",
-      "integrity": "sha512-Md+Juc7M3uOdbAFwOYlTrccIZ7oCFuzrhKYQjdeUEW/sE1hv17Jp/Bws+ReOPpGVBTYCBoYo+G17V5Qo8QQ75A==",
-      "dev": true
-    },
-    "css-value": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/css-value/-/css-value-0.0.1.tgz",
-      "integrity": "sha512-FUV3xaJ63buRLgHrLQVlVgQnQdR4yqdLGaDu7g8CQcWjInDfM9plBTPI9FRfpahju1UBSaMckeb2/46ApS/V1Q==",
-      "dev": true
-    },
-    "data-uri-to-buffer": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
-      "dev": true
-    },
-    "debounce": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
-      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
-      "dev": true
-    },
-    "debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "requires": {
-        "ms": "2.1.2"
-      }
-    },
-    "decamelize": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
-      "integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==",
-      "dev": true
-    },
-    "decode-uri-component": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
-      "dev": true
-    },
-    "decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dev": true,
-      "requires": {
-        "mimic-response": "^3.1.0"
-      },
-      "dependencies": {
-        "mimic-response": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-          "dev": true
-        }
-      }
-    },
-    "deep-eql": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "type-detect": "^4.0.0"
-      }
-    },
-    "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
-      "dev": true
-    },
-    "deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true
-    },
-    "deepmerge-ts": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-5.1.0.tgz",
-      "integrity": "sha512-eS8dRJOckyo9maw9Tu5O5RUi/4inFLrnoLkBe3cPfDMx3WZioXtmOew4TXQaxq7Rhl4xjDtR7c6x8nNTxOvbFw==",
-      "dev": true
-    },
-    "default-gateway": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
-      "integrity": "sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==",
-      "dev": true,
-      "requires": {
-        "execa": "^5.0.0"
-      }
-    },
-    "defer-to-connect": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-      "dev": true
-    },
-    "define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
-      "requires": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      }
-    },
-    "define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
-      "dev": true
-    },
-    "degenerator": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
-      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
-      "dev": true,
-      "requires": {
-        "ast-types": "^0.13.4",
-        "escodegen": "^2.1.0",
-        "esprima": "^4.0.1"
-      }
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true
-    },
-    "delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "dev": true
-    },
-    "depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true
-    },
-    "dependency-graph": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
-      "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
-      "dev": true
-    },
-    "dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true
-    },
-    "destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "dev": true
-    },
-    "detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-      "dev": true
-    },
-    "devtools-protocol": {
-      "version": "0.0.1312386",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
-      "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
-      "dev": true
-    },
-    "diff": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
-      "dev": true
-    },
-    "dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "requires": {
-        "path-type": "^4.0.0"
-      }
-    },
-    "dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dev": true,
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
-      "dev": true
-    },
-    "duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-      "dev": true,
-      "requires": {
-        "readable-stream": "^2.0.2"
-      }
-    },
-    "eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true
-    },
-    "edge-paths": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/edge-paths/-/edge-paths-3.0.5.tgz",
-      "integrity": "sha512-sB7vSrDnFa4ezWQk9nZ/n0FdpdUuC6R1EOrlU3DL+bovcNFK28rqu2emmAUjujYEJTWIgQGqgVVWUZXMnc8iWg==",
-      "dev": true,
-      "requires": {
-        "@types/which": "^2.0.1",
-        "which": "^2.0.2"
-      }
-    },
-    "edgedriver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-5.5.0.tgz",
-      "integrity": "sha512-qQIjDQ62cbDcoZ8AcN6PxQekOwGDZcTkdZj5qr6Ew1i4mMi3R0d1Y6DKlyUnkBs5GXUYua5wKB0XHMLj6FAChQ==",
-      "dev": true,
-      "requires": {
-        "@wdio/logger": "^8.28.0",
-        "decamelize": "^6.0.0",
-        "edge-paths": "^3.0.5",
-        "node-fetch": "^3.3.2",
-        "unzipper": "^0.11.6",
-        "which": "^4.0.0"
-      },
-      "dependencies": {
-        "isexe": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-          "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
-          "dev": true
-        },
-        "which": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-          "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
-          "dev": true,
-          "requires": {
-            "isexe": "^3.1.1"
-          }
-        }
-      }
-    },
-    "ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "dev": true
-    },
-    "emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true
-    },
-    "encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "dev": true
-    },
-    "end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
-      "requires": {
-        "once": "^1.4.0"
-      }
-    },
-    "entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true
-    },
-    "errorstacks": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/errorstacks/-/errorstacks-2.4.1.tgz",
-      "integrity": "sha512-jE4i0SMYevwu/xxAuzhly/KTwtj0xDhbzB6m1xPImxTkw8wcCbgarOQPfCVMi5JKVyW7in29pNJCCJrry3Ynnw==",
-      "dev": true
-    },
-    "es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-      "dev": true,
-      "requires": {
-        "get-intrinsic": "^1.2.4"
-      }
-    },
-    "es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true
-    },
-    "es-module-lexer": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.3.tgz",
-      "integrity": "sha512-i1gCgmR9dCl6Vil6UKPI/trA69s08g/syhiDK9TG0Nf1RJjjFI+AzoWW7sPufzkgYAn861skuCwJa0pIIHYxvg==",
-      "dev": true
-    },
-    "esbuild": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
-      "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
-      "dev": true,
-      "requires": {
-        "@esbuild/aix-ppc64": "0.19.12",
-        "@esbuild/android-arm": "0.19.12",
-        "@esbuild/android-arm64": "0.19.12",
-        "@esbuild/android-x64": "0.19.12",
-        "@esbuild/darwin-arm64": "0.19.12",
-        "@esbuild/darwin-x64": "0.19.12",
-        "@esbuild/freebsd-arm64": "0.19.12",
-        "@esbuild/freebsd-x64": "0.19.12",
-        "@esbuild/linux-arm": "0.19.12",
-        "@esbuild/linux-arm64": "0.19.12",
-        "@esbuild/linux-ia32": "0.19.12",
-        "@esbuild/linux-loong64": "0.19.12",
-        "@esbuild/linux-mips64el": "0.19.12",
-        "@esbuild/linux-ppc64": "0.19.12",
-        "@esbuild/linux-riscv64": "0.19.12",
-        "@esbuild/linux-s390x": "0.19.12",
-        "@esbuild/linux-x64": "0.19.12",
-        "@esbuild/netbsd-x64": "0.19.12",
-        "@esbuild/openbsd-x64": "0.19.12",
-        "@esbuild/sunos-x64": "0.19.12",
-        "@esbuild/win32-arm64": "0.19.12",
-        "@esbuild/win32-ia32": "0.19.12",
-        "@esbuild/win32-x64": "0.19.12"
-      }
-    },
-    "escalade": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
-      "dev": true
-    },
-    "escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "dev": true
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true
-    },
-    "escodegen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "dev": true,
-      "requires": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
-    "esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
-    },
-    "estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true
-    },
-    "estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true
-    },
-    "esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true
-    },
-    "etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-      "dev": true
-    },
-    "event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true
-    },
-    "events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true
-    },
-    "execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "dependencies": {
-        "signal-exit": {
-          "version": "3.0.7",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-          "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-          "dev": true
-        }
-      }
-    },
-    "extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "requires": {
-        "@types/yauzl": "^2.9.1",
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        }
-      }
-    },
-    "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
-      "dev": true
-    },
-    "fast-fifo": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-      "dev": true
-    },
-    "fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
-      "dev": true,
-      "requires": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
-      }
-    },
-    "fastq": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
-      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
-      "dev": true,
-      "requires": {
-        "reusify": "^1.0.4"
-      }
-    },
-    "fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "requires": {
-        "pend": "~1.2.0"
-      }
-    },
-    "fd-slicer2": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer2/-/fd-slicer2-1.2.0.tgz",
-      "integrity": "sha512-3lBUNUckhMZduCc4g+Pw4Ve16LD9vpX9b8qUkkKq2mgDRLYWzblszZH2luADnJqjJe+cypngjCuKRm/IW12rRw==",
-      "dev": true,
-      "requires": {
-        "pend": "^1.2.0"
-      }
-    },
-    "fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "dev": true,
-      "requires": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      }
-    },
-    "fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
-      "requires": {
-        "to-regex-range": "^5.0.1"
-      }
-    },
-    "filter-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
-      "dev": true
-    },
-    "find-replace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
-      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
-      "dev": true,
-      "requires": {
-        "array-back": "^3.0.1"
-      }
-    },
-    "flushwritable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/flushwritable/-/flushwritable-1.0.0.tgz",
-      "integrity": "sha512-3VELfuWCLVzt5d2Gblk8qcqFro6nuwvxwMzHaENVDHI7rxcBRtMCwTk/E9FXcgh+82DSpavPNDueA9+RxXJoFg==",
-      "dev": true
-    },
-    "foreground-child": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^7.0.0",
-        "signal-exit": "^4.0.1"
-      }
-    },
-    "form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      }
-    },
-    "form-data-encoder": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
-      "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
-      "dev": true
-    },
-    "formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
-      "requires": {
-        "fetch-blob": "^3.1.2"
-      }
-    },
-    "fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-      "dev": true
-    },
-    "fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true
-    },
-    "fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      }
-    },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
-    },
-    "fstream": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      },
-      "dependencies": {
-        "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "glob": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.1.1",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.6"
-          }
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
-      }
-    },
-    "function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true
-    },
-    "geckodriver": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-4.4.0.tgz",
-      "integrity": "sha512-Y/Np2VkAhBkJoFAIY3pKH3rICUcR5rH9VD6EHwh0CqUIh6Opzr/NFwfcQenYfbRT/659R15/35LpA1s6h9wPPg==",
-      "dev": true,
-      "requires": {
-        "@wdio/logger": "^8.28.0",
-        "decamelize": "^6.0.0",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.4",
-        "node-fetch": "^3.3.2",
-        "tar-fs": "^3.0.6",
-        "unzipper": "^0.11.4",
-        "which": "^4.0.0"
-      },
-      "dependencies": {
-        "isexe": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-          "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
-          "dev": true
-        },
-        "which": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-          "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
-          "dev": true,
-          "requires": {
-            "isexe": "^3.1.1"
-          }
-        }
-      }
-    },
-    "get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
-    },
-    "get-func-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-      "dev": true,
-      "peer": true
-    },
-    "get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-      "dev": true,
-      "requires": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
-      }
-    },
-    "get-port": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
-      "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
-      "dev": true
-    },
-    "get-ready": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/get-ready/-/get-ready-1.0.0.tgz",
-      "integrity": "sha512-mFXCZPJIlcYcth+N8267+mghfYN9h3EhsDa6JSnbA3Wrhh/XFpuowviFcsDeYZtKspQyWyJqfs4O6P8CHeTwzw==",
-      "dev": true
-    },
-    "get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true
-    },
-    "get-tsconfig": {
-      "version": "4.7.5",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.5.tgz",
-      "integrity": "sha512-ZCuZCnlqNzjb4QprAzXKdpp/gh6KTxSJuw3IBsPnV/7fV4NxC9ckB+vPTt8w7fJA0TaSD7c55BR47JD6MEDyDw==",
-      "dev": true,
-      "requires": {
-        "resolve-pkg-maps": "^1.0.0"
-      }
-    },
-    "get-uri": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
-      "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
-      "dev": true,
-      "requires": {
-        "basic-ftp": "^5.0.2",
-        "data-uri-to-buffer": "^6.0.2",
-        "debug": "^4.3.4",
-        "fs-extra": "^11.2.0"
-      }
-    },
-    "glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
-      "requires": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      }
-    },
-    "glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "requires": {
-        "is-glob": "^4.0.1"
-      }
-    },
-    "globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "requires": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      }
-    },
-    "gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
-      "requires": {
-        "get-intrinsic": "^1.1.3"
-      }
-    },
-    "got": {
-      "version": "11.8.6",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
-      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
-      "dev": true,
-      "requires": {
-        "@sindresorhus/is": "^4.0.0",
-        "@szmarczak/http-timer": "^4.0.5",
-        "@types/cacheable-request": "^6.0.1",
-        "@types/responselike": "^1.0.0",
-        "cacheable-lookup": "^5.0.3",
-        "cacheable-request": "^7.0.2",
-        "decompress-response": "^6.0.0",
-        "http2-wrapper": "^1.0.0-beta.5.2",
-        "lowercase-keys": "^2.0.0",
-        "p-cancelable": "^2.0.0",
-        "responselike": "^2.0.0"
-      }
-    },
-    "graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
-    },
-    "grapheme-splitter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-      "dev": true
-    },
-    "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true
-    },
-    "has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
-      "requires": {
-        "es-define-property": "^1.0.0"
-      }
-    },
-    "has-proto": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-      "dev": true
-    },
-    "has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true
-    },
-    "has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
-      "requires": {
-        "has-symbols": "^1.0.3"
-      }
-    },
-    "hash.js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
-    "hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.2"
-      }
-    },
-    "header-case": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
-      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-      "dev": true,
-      "requires": {
-        "capital-case": "^1.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "html-escaper": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true
-    },
-    "html-minifier-terser": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
-      "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
-      "dev": true,
-      "requires": {
-        "camel-case": "^4.1.2",
-        "clean-css": "~5.3.2",
-        "commander": "^10.0.0",
-        "entities": "^4.4.0",
-        "param-case": "^3.0.4",
-        "relateurl": "^0.2.7",
-        "terser": "^5.15.1"
-      }
-    },
-    "http-assert": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
-      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
-      "dev": true,
-      "requires": {
-        "deep-equal": "~1.0.1",
-        "http-errors": "~1.8.0"
-      }
-    },
-    "http-cache-semantics": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
-      "dev": true
-    },
-    "http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
-      "dev": true,
-      "requires": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.1"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-          "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-          "dev": true
-        }
-      }
-    },
-    "http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
-      "requires": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      }
-    },
-    "http2-wrapper": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
-      "dev": true,
-      "requires": {
-        "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.0.0"
-      }
-    },
-    "https-proxy-agent": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
-      "dev": true,
-      "requires": {
-        "agent-base": "^7.0.2",
-        "debug": "4"
-      }
-    },
-    "human-signals": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "dev": true
-    },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
-    "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
-    },
-    "ignore": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
-      "dev": true
-    },
-    "import-meta-resolve": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
-      "integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
-      "dev": true
-    },
-    "inflation": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/inflation/-/inflation-2.1.0.tgz",
-      "integrity": "sha512-t54PPJHG1Pp7VQvxyVCJ9mBbjG3Hqryges9bXoOO6GExCPa+//i/d5GSuFtpx3ALLd7lgIAur6zrIlBQyJuMlQ==",
-      "dev": true
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
-    },
-    "internal-ip": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-6.2.0.tgz",
-      "integrity": "sha512-D8WGsR6yDt8uq7vDMu7mjcR+yRMm3dW8yufyChmszWRjcSHuxLBkR3GdS2HZAjodsaGuCvXeEJpueisXJULghg==",
-      "dev": true,
-      "requires": {
-        "default-gateway": "^6.0.0",
-        "ipaddr.js": "^1.9.1",
-        "is-ip": "^3.1.0",
-        "p-event": "^4.2.0"
-      }
-    },
-    "ip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
-      "dev": true
-    },
-    "ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "dev": true,
-      "requires": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      }
-    },
-    "ip-regex": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
-      "dev": true
-    },
-    "ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "dev": true
-    },
-    "is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
-      "requires": {
-        "binary-extensions": "^2.0.0"
-      }
-    },
-    "is-builtin-module": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
-      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
-      "dev": true,
-      "requires": {
-        "builtin-modules": "^3.3.0"
-      }
-    },
-    "is-core-module": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
-      "dev": true,
-      "requires": {
-        "hasown": "^2.0.0"
-      }
-    },
-    "is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "dev": true
-    },
-    "is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true
-    },
-    "is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true
-    },
-    "is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-      "dev": true,
-      "requires": {
-        "has-tostringtag": "^1.0.0"
-      }
-    },
-    "is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
-      "requires": {
-        "is-extglob": "^2.1.1"
-      }
-    },
-    "is-ip": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
-      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
-      "dev": true,
-      "requires": {
-        "ip-regex": "^4.0.0"
-      }
-    },
-    "is-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
-      "dev": true
-    },
-    "is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
-    },
-    "is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true
-    },
-    "is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true
-    },
-    "is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dev": true,
-      "requires": {
-        "is-docker": "^2.0.0"
-      }
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true
-    },
-    "isbinaryfile": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.2.tgz",
-      "integrity": "sha512-GvcjojwonMjWbTkfMpnVHVqXW/wKMYDfEpY94/8zy8HFMOqb/VL6oeONq9v87q4ttVlaTLnGXnJD4B5B1OTGIg==",
-      "dev": true
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
-    },
-    "istanbul-lib-coverage": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
-      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
-      "dev": true
-    },
-    "istanbul-lib-report": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
-      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
-      "dev": true,
-      "requires": {
-        "istanbul-lib-coverage": "^3.0.0",
-        "make-dir": "^4.0.0",
-        "supports-color": "^7.1.0"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
-    "istanbul-reports": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
-      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
-      "dev": true,
-      "requires": {
-        "html-escaper": "^2.0.0",
-        "istanbul-lib-report": "^3.0.0"
-      }
-    },
-    "jackspeak": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.1.2.tgz",
-      "integrity": "sha512-kWmLKn2tRtfYMF/BakihVVRzBKOxz4gJMiL2Rj91WnAB5TPZumSH99R/Yf1qE1u4uRimvCSJfm6hnxohXeEXjQ==",
-      "dev": true,
-      "requires": {
-        "@isaacs/cliui": "^8.0.2",
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
-    },
-    "jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "dev": true
-    },
-    "json-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true
-    },
-    "jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.6",
-        "universalify": "^2.0.0"
-      }
-    },
-    "just-extend": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
-      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
-      "dev": true
-    },
-    "keygrip": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
-      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
-      "dev": true,
-      "requires": {
-        "tsscmp": "1.0.6"
-      }
-    },
-    "keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
-      "requires": {
-        "json-buffer": "3.0.1"
-      }
-    },
-    "koa": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/koa/-/koa-2.15.3.tgz",
-      "integrity": "sha512-j/8tY9j5t+GVMLeioLaxweJiKUayFhlGqNTzf2ZGwL0ZCQijd2RLHK0SLW5Tsko8YyyqCZC2cojIb0/s62qTAg==",
-      "dev": true,
-      "requires": {
-        "accepts": "^1.3.5",
-        "cache-content-type": "^1.0.0",
-        "content-disposition": "~0.5.2",
-        "content-type": "^1.0.4",
-        "cookies": "~0.9.0",
-        "debug": "^4.3.2",
-        "delegates": "^1.0.0",
-        "depd": "^2.0.0",
-        "destroy": "^1.0.4",
-        "encodeurl": "^1.0.2",
-        "escape-html": "^1.0.3",
-        "fresh": "~0.5.2",
-        "http-assert": "^1.3.0",
-        "http-errors": "^1.6.3",
-        "is-generator-function": "^1.0.7",
-        "koa-compose": "^4.1.0",
-        "koa-convert": "^2.0.0",
-        "on-finished": "^2.3.0",
-        "only": "~0.0.2",
-        "parseurl": "^1.3.2",
-        "statuses": "^1.5.0",
-        "type-is": "^1.6.16",
-        "vary": "^1.1.2"
-      }
-    },
-    "koa-compose": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
-      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
-      "dev": true
-    },
-    "koa-convert": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-2.0.0.tgz",
-      "integrity": "sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA==",
-      "dev": true,
-      "requires": {
-        "co": "^4.6.0",
-        "koa-compose": "^4.1.0"
-      }
-    },
-    "koa-etag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/koa-etag/-/koa-etag-4.0.0.tgz",
-      "integrity": "sha512-1cSdezCkBWlyuB9l6c/IFoe1ANCDdPBxkDkRiaIup40xpUub6U/wwRXoKBZw/O5BifX9OlqAjYnDyzM6+l+TAg==",
-      "dev": true,
-      "requires": {
-        "etag": "^1.8.1"
-      }
-    },
-    "koa-send": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/koa-send/-/koa-send-5.0.1.tgz",
-      "integrity": "sha512-tmcyQ/wXXuxpDxyNXv5yNNkdAMdFRqwtegBXUaowiQzUKqJehttS0x2j0eOZDQAyloAth5w6wwBImnFzkUz3pQ==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.1.1",
-        "http-errors": "^1.7.3",
-        "resolve-path": "^1.4.0"
-      }
-    },
-    "koa-static": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/koa-static/-/koa-static-5.0.0.tgz",
-      "integrity": "sha512-UqyYyH5YEXaJrf9S8E23GoJFQZXkBVJ9zYYMPGz919MSX1KuvAcycIuS0ci150HCoPf4XQVhQ84Qf8xRPWxFaQ==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.1.0",
-        "koa-send": "^5.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
-    },
-    "ky": {
-      "version": "0.33.3",
-      "resolved": "https://registry.npmjs.org/ky/-/ky-0.33.3.tgz",
-      "integrity": "sha512-CasD9OCEQSFIam2U8efFK81Yeg8vNMTBUqtMOHlrcWQHqUX3HeCl9Dr31u4toV7emlH8Mymk5+9p0lL6mKb/Xw==",
-      "dev": true
-    },
-    "lazystream": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
-      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
-      "dev": true,
-      "requires": {
-        "readable-stream": "^2.0.5"
-      }
-    },
-    "lighthouse-logger": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.4.2.tgz",
-      "integrity": "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==",
-      "dev": true,
-      "requires": {
-        "debug": "^2.6.9",
-        "marky": "^1.2.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-          "dev": true
-        }
-      }
-    },
-    "lightningcss": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.25.0.tgz",
-      "integrity": "sha512-B08o6QQikGaY4rPuQohtFVE+X2++mm/QemwAJ/1sgnMgTwwUnafJbTmSSBWC8Tv4JPfhelXZB6sWA0Y/6eYJmQ==",
-      "dev": true,
-      "requires": {
-        "detect-libc": "^1.0.3",
-        "lightningcss-darwin-arm64": "1.25.0",
-        "lightningcss-darwin-x64": "1.25.0",
-        "lightningcss-freebsd-x64": "1.25.0",
-        "lightningcss-linux-arm-gnueabihf": "1.25.0",
-        "lightningcss-linux-arm64-gnu": "1.25.0",
-        "lightningcss-linux-arm64-musl": "1.25.0",
-        "lightningcss-linux-x64-gnu": "1.25.0",
-        "lightningcss-linux-x64-musl": "1.25.0",
-        "lightningcss-win32-x64-msvc": "1.25.0"
-      }
-    },
-    "lightningcss-darwin-arm64": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.25.0.tgz",
-      "integrity": "sha512-neCU5PrQUAec/b2mpXv13rrBWObQVaG/y0yhGKzAqN9cj7lOv13Wegnpiro0M66XAxx/cIkZfmJstRfriOR2SQ==",
-      "dev": true,
-      "optional": true
-    },
-    "lightningcss-darwin-x64": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.25.0.tgz",
-      "integrity": "sha512-h1XBxDHdED7TY4/1V30UNjiqXceGbcL8ARhUfbf8CWAEhD7wMKK/4UqMHi94RDl31ko4LTmt9fS2u1uyeWYE6g==",
-      "dev": true,
-      "optional": true
-    },
-    "lightningcss-freebsd-x64": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.25.0.tgz",
-      "integrity": "sha512-f7v6QwrqCFtQOG1Y7iZ4P1/EAmMsyUyRBrYbSmDxihMzdsL7xyTM753H2138/oCpam+maw2RZrXe/NA1r/I5cQ==",
-      "dev": true,
-      "optional": true
-    },
-    "lightningcss-linux-arm-gnueabihf": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.25.0.tgz",
-      "integrity": "sha512-7KSVcjci9apHxUKNjiLKXn8hVQJqCtwFg5YNvTeKi/BM91A9lQTuO57RpmpPbRIb20Qm8vR7fZtL1iL5Yo3j9A==",
-      "dev": true,
-      "optional": true
-    },
-    "lightningcss-linux-arm64-gnu": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.25.0.tgz",
-      "integrity": "sha512-1+6tuAsUyMVG5N2rzgwaOOf84yEU+Gjl71b+wLcz26lyM/ohgFgeqPWeB/Dor0wyUnq7vg184l8goGT26cRxoQ==",
-      "dev": true,
-      "optional": true
-    },
-    "lightningcss-linux-arm64-musl": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.25.0.tgz",
-      "integrity": "sha512-4kw3ZnGQzxD8KkaB4doqfi32hP5h3o04OlrdfZ7T9VLTbUxeh3YZUKcJmhINV2rdMOOmVODqaRw1kuvvF16Q+Q==",
-      "dev": true,
-      "optional": true
-    },
-    "lightningcss-linux-x64-gnu": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.25.0.tgz",
-      "integrity": "sha512-oVEP5rBrFQB5V7fRIPYkDxKLmd2fAbz9VagKWIRu1TlYDUFWXK4F3KztAtAKuD7tLMBSGGi1LMUueFzVe+cZbw==",
-      "dev": true,
-      "optional": true
-    },
-    "lightningcss-linux-x64-musl": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.25.0.tgz",
-      "integrity": "sha512-7ssY6HwCvmPDohqtXuZG2Mh9q32LbVBhiF/SS/VMj2jUcXcsBilUEviq/zFDzhZMxl5f1lXi5/+mCuSGrMir1A==",
-      "dev": true,
-      "optional": true
-    },
-    "lightningcss-win32-x64-msvc": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.25.0.tgz",
-      "integrity": "sha512-DUVxj1S6dCQkixQ5qiHcYojamxE02bgmSpc4p6lejPwW7WRd/pvDPDAr+BvZWAkX5MRphxB7ei6+93+42ZtvmQ==",
-      "dev": true,
-      "optional": true
-    },
-    "lit": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-      "requires": {
-        "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "lit-element": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-      "requires": {
-        "@lit-labs/ssr-dom-shim": "^1.1.0",
-        "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "lit-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-      "requires": {
-        "@types/trusted-types": "^2.0.2"
-      }
-    },
-    "locate-app": {
-      "version": "2.4.15",
-      "resolved": "https://registry.npmjs.org/locate-app/-/locate-app-2.4.15.tgz",
-      "integrity": "sha512-oAGHATXPUHSQ74Om+3dXBRNYtCzU7Wzuhlj/WIZchqHb/5/TGJRzLEtHipMDOak0UZG9U365RMXyBzgV/fhOww==",
-      "dev": true,
-      "requires": {
-        "@promptbook/utils": "0.50.0-10",
-        "type-fest": "2.13.0",
-        "userhome": "1.0.0"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "2.13.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.13.0.tgz",
-          "integrity": "sha512-lPfAm42MxE4/456+QyIaaVBAwgpJb6xZ8PRu09utnhPdWwcyj9vgy6Sq0Z5yNbJ21EdxB5dRU/Qg8bsyAMtlcw==",
-          "dev": true
-        }
-      }
-    },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
-    },
-    "lodash.assignwith": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz",
-      "integrity": "sha512-ZznplvbvtjK2gMvnQ1BR/zqPFZmS6jbK4p+6Up4xcRYA7yMIwxHCfbTcrYxXKzzqLsQ05eJPVznEW3tuwV7k1g==",
-      "dev": true
-    },
-    "lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "dev": true
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
-      "dev": true
-    },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "dev": true
-    },
-    "lodash.zip": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
-      "integrity": "sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==",
-      "dev": true
-    },
-    "log-update": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
-      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "^4.3.0",
-        "cli-cursor": "^3.1.0",
-        "slice-ansi": "^4.0.0",
-        "wrap-ansi": "^6.2.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        },
-        "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        }
-      }
-    },
-    "loglevel": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.1.tgz",
-      "integrity": "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==",
-      "dev": true
-    },
-    "loglevel-plugin-prefix": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
-      "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
-      "dev": true
-    },
-    "loupe": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "get-func-name": "^2.0.1"
-      }
-    },
-    "lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "lowercase-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-      "dev": true
-    },
-    "lru-cache": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.5.tgz",
-      "integrity": "sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==",
-      "dev": true
-    },
-    "make-dir": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
-      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
-      "dev": true,
-      "requires": {
-        "semver": "^7.5.3"
-      }
-    },
-    "marky": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz",
-      "integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q==",
-      "dev": true
-    },
-    "media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "dev": true
-    },
-    "merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true
-    },
-    "merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true
-    },
-    "micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
-      "dev": true,
-      "requires": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      }
-    },
-    "mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
-    },
-    "mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "requires": {
-        "mime-db": "1.52.0"
-      }
-    },
-    "mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true
-    },
-    "mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "dev": true
-    },
-    "minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "dev": true
-    },
-    "minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "^2.0.1"
-      }
-    },
-    "minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true
-    },
-    "minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true
-    },
-    "mitt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "dev": true
-    },
-    "mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true
-    },
-    "mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true
-    },
-    "moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "dev": true
-    },
-    "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "nanocolors": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.2.13.tgz",
-      "integrity": "sha512-0n3mSAQLPpGLV9ORXT5+C/D4mwew7Ebws69Hx4E2sgz2ZA5+32Q80B9tL8PbL7XHnRDiAxH/pnrUJ9a4fkTNTA==",
-      "dev": true
-    },
-    "nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-      "dev": true
-    },
-    "negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "dev": true
-    },
-    "netmask": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
-      "dev": true
-    },
-    "nise": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.9.tgz",
-      "integrity": "sha512-qOnoujW4SV6e40dYxJOb3uvuoPHtmLzIk4TFo+j0jPJoC+5Z9xja5qH5JZobEPsa8+YYphMrOSwnrshEhG2qww==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^3.0.0",
-        "@sinonjs/fake-timers": "^11.2.2",
-        "@sinonjs/text-encoding": "^0.7.2",
-        "just-extend": "^6.2.0",
-        "path-to-regexp": "^6.2.1"
-      },
-      "dependencies": {
-        "@sinonjs/commons": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
-          "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
-          "dev": true,
-          "requires": {
-            "type-detect": "4.0.8"
-          }
-        },
-        "@sinonjs/fake-timers": {
-          "version": "11.3.1",
-          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.3.1.tgz",
-          "integrity": "sha512-EVJO7nW5M/F5Tur0Rf2z/QoMo+1Ia963RiMtapiQrEWvY0iBUvADo8Beegwjpnle5BHkyHuoxSTW3jF43H1XRA==",
-          "dev": true,
-          "requires": {
-            "@sinonjs/commons": "^3.0.1"
-          }
-        }
-      }
-    },
-    "no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dev": true,
-      "requires": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "dev": true
-    },
-    "node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
-      "requires": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "dependencies": {
-        "data-uri-to-buffer": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-          "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-          "dev": true
-        }
-      }
-    },
-    "normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
-    },
-    "normalize-url": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
-      "dev": true
-    },
-    "npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
-      "requires": {
-        "path-key": "^3.0.0"
-      }
-    },
-    "object-inspect": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
-      "dev": true
-    },
-    "on-finished": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "dev": true,
-      "requires": {
-        "ee-first": "1.1.1"
-      }
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "requires": {
-        "wrappy": "1"
-      }
-    },
-    "onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
-      "requires": {
-        "mimic-fn": "^2.1.0"
-      }
-    },
-    "only": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
-      "integrity": "sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ==",
-      "dev": true
-    },
-    "open": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
-      "dev": true,
-      "requires": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
-      }
-    },
-    "p-cancelable": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
-      "dev": true
-    },
-    "p-event": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
-      "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
-      "dev": true,
-      "requires": {
-        "p-timeout": "^3.1.0"
-      }
-    },
-    "p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
-      "dev": true
-    },
-    "p-timeout": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
-      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
-      "dev": true,
-      "requires": {
-        "p-finally": "^1.0.0"
-      }
-    },
-    "pac-proxy-agent": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.1.tgz",
-      "integrity": "sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A==",
-      "dev": true,
-      "requires": {
-        "@tootallnate/quickjs-emscripten": "^0.23.0",
-        "agent-base": "^7.0.2",
-        "debug": "^4.3.4",
-        "get-uri": "^6.0.1",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.2",
-        "pac-resolver": "^7.0.0",
-        "socks-proxy-agent": "^8.0.2"
-      }
-    },
-    "pac-resolver": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
-      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
-      "dev": true,
-      "requires": {
-        "degenerator": "^5.0.0",
-        "netmask": "^2.0.2"
-      }
-    },
-    "package-json-from-dist": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
-      "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
-      "dev": true
-    },
-    "param-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dev": true,
-      "requires": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "parse5": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-      "dev": true
-    },
-    "parseurl": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "dev": true
-    },
-    "pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dev": true,
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "path-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
-      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-      "dev": true,
-      "requires": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true
-    },
-    "path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true
-    },
-    "path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
-    },
-    "path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "10.4.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-          "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-          "dev": true
-        }
-      }
-    },
-    "path-to-regexp": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
-      "dev": true
-    },
-    "path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true
-    },
-    "pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true,
-      "peer": true
-    },
-    "pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true
-    },
-    "picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
-      "dev": true
-    },
-    "picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true
-    },
-    "pixelmatch": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.3.0.tgz",
-      "integrity": "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==",
-      "dev": true,
-      "requires": {
-        "pngjs": "^6.0.0"
-      },
-      "dependencies": {
-        "pngjs": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
-          "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
-          "dev": true
-        }
-      }
-    },
-    "playwright": {
-      "version": "1.44.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.1.tgz",
-      "integrity": "sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==",
-      "dev": true,
-      "requires": {
-        "fsevents": "2.3.2",
-        "playwright-core": "1.44.1"
-      }
-    },
-    "playwright-core": {
-      "version": "1.44.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.1.tgz",
-      "integrity": "sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==",
-      "dev": true
-    },
-    "pngjs": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
-      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
-      "dev": true
-    },
-    "portfinder": {
-      "version": "1.0.32",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
-      "integrity": "sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==",
-      "dev": true,
-      "requires": {
-        "async": "^2.6.4",
-        "debug": "^3.2.7",
-        "mkdirp": "^0.5.6"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.6"
-          }
-        }
-      }
-    },
-    "prettier": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
-      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
-      "dev": true
-    },
-    "process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "dev": true
-    },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
-    },
-    "progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true
-    },
-    "proxy-agent": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
-      "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
-      "dev": true,
-      "requires": {
-        "agent-base": "^7.0.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.3",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.0.1",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.2"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "7.18.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-          "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-          "dev": true
-        }
-      }
-    },
-    "proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
-    },
-    "pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
-    "punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true
-    },
-    "puppeteer-core": {
-      "version": "22.15.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.15.0.tgz",
-      "integrity": "sha512-cHArnywCiAAVXa3t4GGL2vttNxh7GqXtIYGym99egkNJ3oG//wL9LkvO4WE8W1TJe95t1F1ocu9X4xWaGsOKOA==",
-      "dev": true,
-      "requires": {
-        "@puppeteer/browsers": "2.3.0",
-        "chromium-bidi": "0.6.3",
-        "debug": "^4.3.6",
-        "devtools-protocol": "0.0.1312386",
-        "ws": "^8.18.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-          "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ws": {
-          "version": "8.18.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-          "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-          "dev": true,
-          "requires": {}
-        }
-      }
-    },
-    "qs": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
-      "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
-      "dev": true,
-      "requires": {
-        "side-channel": "^1.0.6"
-      }
-    },
-    "query-selector-shadow-dom": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
-      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
-      "dev": true
-    },
-    "query-string": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
-      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
-      "dev": true,
-      "requires": {
-        "decode-uri-component": "^0.2.2",
-        "filter-obj": "^1.1.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
-      }
-    },
-    "queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true
-    },
-    "queue-tick": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
-      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
-      "dev": true
-    },
-    "quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "dev": true
-    },
-    "raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-      "dev": true,
-      "requires": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "http-errors": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-          "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-          "dev": true,
-          "requires": {
-            "depd": "2.0.0",
-            "inherits": "2.0.4",
-            "setprototypeof": "1.2.0",
-            "statuses": "2.0.1",
-            "toidentifier": "1.0.1"
-          }
-        },
-        "statuses": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-          "dev": true
-        }
-      }
-    },
-    "readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        }
-      }
-    },
-    "readdir-glob": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
-      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
-      "dev": true,
-      "requires": {
-        "minimatch": "^5.1.0"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "5.1.6",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        }
-      }
-    },
-    "readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "requires": {
-        "picomatch": "^2.2.1"
-      }
-    },
-    "relateurl": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-      "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
-      "dev": true
-    },
-    "require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true
-    },
-    "resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
-      "requires": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      }
-    },
-    "resolve-alpn": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-      "dev": true
-    },
-    "resolve-path": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/resolve-path/-/resolve-path-1.4.0.tgz",
-      "integrity": "sha512-i1xevIst/Qa+nA9olDxLWnLk8YZbi8R/7JPbCMcgyWaFR6bKWaexgJgEB5oc2PKMjYdrHynyz0NY+if+H98t1w==",
-      "dev": true,
-      "requires": {
-        "http-errors": "~1.6.2",
-        "path-is-absolute": "1.0.1"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-          "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-          "dev": true
-        },
-        "http-errors": {
-          "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-          "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
-          "dev": true,
-          "requires": {
-            "depd": "~1.1.2",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-          "dev": true
-        },
-        "setprototypeof": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-          "dev": true
-        }
-      }
-    },
-    "resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true
-    },
-    "responselike": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
-      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
-      "dev": true,
-      "requires": {
-        "lowercase-keys": "^2.0.0"
-      }
-    },
-    "resq": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/resq/-/resq-1.11.0.tgz",
-      "integrity": "sha512-G10EBz+zAAy3zUd/CDoBbXRL6ia9kOo3xRHrMDsHljI0GDkhYlyjwoCx5+3eCC4swi1uCoZQhskuJkj7Gp57Bw==",
-      "dev": true,
-      "requires": {
-        "fast-deep-equal": "^2.0.1"
-      }
-    },
-    "restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
-      "requires": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "dependencies": {
-        "signal-exit": {
-          "version": "3.0.7",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-          "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-          "dev": true
-        }
-      }
-    },
-    "reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true
-    },
-    "rgb2hex": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.2.5.tgz",
-      "integrity": "sha512-22MOP1Rh7sAo1BZpDG6R5RFYzR2lYEgwq7HEmyW2qcsOqR2lQKmn+O//xV3YG/0rrhMC6KVX2hU+ZXuaw9a5bw==",
-      "dev": true
-    },
-    "rimraf": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
-      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
-      "dev": true,
-      "requires": {
-        "glob": "^10.3.7"
-      }
-    },
-    "rollup": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.18.0.tgz",
-      "integrity": "sha512-QmJz14PX3rzbJCN1SG4Xe/bAAX2a6NpCP8ab2vfu2GiUr8AQcr2nCV/oEO3yneFarB67zk8ShlIyWb2LGTb3Sg==",
-      "dev": true,
-      "requires": {
-        "@rollup/rollup-android-arm-eabi": "4.18.0",
-        "@rollup/rollup-android-arm64": "4.18.0",
-        "@rollup/rollup-darwin-arm64": "4.18.0",
-        "@rollup/rollup-darwin-x64": "4.18.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.18.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.18.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.18.0",
-        "@rollup/rollup-linux-arm64-musl": "4.18.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.18.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.18.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.18.0",
-        "@rollup/rollup-linux-x64-gnu": "4.18.0",
-        "@rollup/rollup-linux-x64-musl": "4.18.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.18.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.18.0",
-        "@rollup/rollup-win32-x64-msvc": "4.18.0",
-        "@types/estree": "1.0.5",
-        "fsevents": "~2.3.2"
-      }
-    },
-    "run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "requires": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
-    "safaridriver": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/safaridriver/-/safaridriver-0.1.2.tgz",
-      "integrity": "sha512-4R309+gWflJktzPXBQCobbWEHlzC4aK3a+Ov3tz2Ib2aBxiwd11phkdIBH1l0EO22x24CJMUQkpKFumRriCSRg==",
-      "dev": true
-    },
-    "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
-    },
-    "saucelabs": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-7.5.0.tgz",
-      "integrity": "sha512-wq89BtE7xb4ns7ApbgAshaUgXHlPoseytPTNwaVQNPwAaD+0klYpBrsCy/Lj77EJ+kf/vKvX1tjhRT67eDyCXg==",
-      "dev": true,
-      "requires": {
-        "change-case": "^4.1.2",
-        "compressing": "^1.10.0",
-        "form-data": "^4.0.0",
-        "got": "^11.8.6",
-        "hash.js": "^1.1.7",
-        "query-string": "^7.1.3",
-        "tunnel": "^0.0.6",
-        "yargs": "^17.2.1"
-      }
-    },
-    "semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true
-    },
-    "sentence-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
-      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-      "dev": true,
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
-    },
-    "serialize-error": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-11.0.3.tgz",
-      "integrity": "sha512-2G2y++21dhj2R7iHAdd0FIzjGwuKZld+7Pl/bTU6YIkrC2ZMbVUjm+luj6A6V34Rv9XfKJDKpTWu9W4Gse1D9g==",
-      "dev": true,
-      "requires": {
-        "type-fest": "^2.12.2"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-          "dev": true
-        }
-      }
-    },
-    "set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
-      "requires": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      }
-    },
-    "setprototypeof": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "dev": true
-    },
-    "shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "requires": {
-        "shebang-regex": "^3.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true
-    },
-    "side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.7",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
-      }
-    },
-    "signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true
-    },
-    "simple-git": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.24.0.tgz",
-      "integrity": "sha512-QqAKee9Twv+3k8IFOFfPB2hnk6as6Y6ACUpwCtQvRYBAes23Wv3SZlHVobAzqcE8gfsisCvPw3HGW3HYM+VYYw==",
-      "dev": true,
-      "requires": {
-        "@kwsites/file-exists": "^1.1.1",
-        "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.4"
-      }
-    },
-    "sinon": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-13.0.2.tgz",
-      "integrity": "sha512-KvOrztAVqzSJWMDoxM4vM+GPys1df2VBoXm+YciyB/OLMamfS3VXh3oGh5WtrAGSzrgczNWFFY22oKb7Fi5eeA==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^1.8.3",
-        "@sinonjs/fake-timers": "^9.1.2",
-        "@sinonjs/samsam": "^6.1.1",
-        "diff": "^5.0.0",
-        "nise": "^5.1.1",
-        "supports-color": "^7.2.0"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
-    "sinon-chai": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
-      "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
-      "dev": true,
-      "requires": {}
-    },
-    "slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true
-    },
-    "slice-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        }
-      }
-    },
-    "smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true
-    },
-    "snake-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
-      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-      "dev": true,
-      "requires": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "socks": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
-      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
-      "dev": true,
-      "requires": {
-        "ip-address": "^9.0.5",
-        "smart-buffer": "^4.2.0"
-      }
-    },
-    "socks-proxy-agent": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.3.tgz",
-      "integrity": "sha512-VNegTZKhuGq5vSD6XNKlbqWhyt/40CgoEw8XxD6dhnm8Jq9IEa3nIa4HwnM8XOqU0CdB0BwWVXusqiFXfHB3+A==",
-      "dev": true,
-      "requires": {
-        "agent-base": "^7.1.1",
-        "debug": "^4.3.4",
-        "socks": "^2.7.1"
-      }
-    },
-    "source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "dev": true
-    },
-    "source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
-    "spacetrim": {
-      "version": "0.11.25",
-      "resolved": "https://registry.npmjs.org/spacetrim/-/spacetrim-0.11.25.tgz",
-      "integrity": "sha512-SWxXDROciuJs9YEYXUBjot5k/cqNGPPbT3QmkInFne4AGc1y+76It+jqU8rfsXKt57RRiunzZn1m9+KfuuNklw==",
-      "dev": true
-    },
-    "split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
-      "dev": true
-    },
-    "split2": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "dev": true
-    },
-    "sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true
-    },
-    "statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
-      "dev": true
-    },
-    "stream-read-all": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/stream-read-all/-/stream-read-all-3.0.1.tgz",
-      "integrity": "sha512-EWZT9XOceBPlVJRrYcykW8jyRSZYbkb/0ZK36uLEmoWVO5gxBOnntNTseNzfREsqxqdfEGQrD8SXQ3QWbBmq8A==",
-      "dev": true
-    },
-    "streamifier": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
-      "integrity": "sha512-zDgl+muIlWzXNsXeyUfOk9dChMjlpkq0DRsxujtYPgyJ676yQ8jEm6zzaaWHFDg5BNcLuif0eD2MTyJdZqXpdg==",
-      "dev": true
-    },
-    "streamx": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.16.1.tgz",
-      "integrity": "sha512-m9QYj6WygWyWa3H1YY69amr4nVgy61xfjys7xO7kviL5rfIEc2naf+ewFiOA+aEJD7y0JO3h2GoiUv4TDwEGzQ==",
-      "dev": true,
-      "requires": {
-        "bare-events": "^2.2.0",
-        "fast-fifo": "^1.1.0",
-        "queue-tick": "^1.0.1"
-      }
-    },
-    "strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
-      "dev": true
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        }
-      }
-    },
-    "string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "requires": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      }
-    },
-    "string-width-cjs": {
-      "version": "npm:string-width@4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "requires": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        }
-      }
-    },
-    "strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^6.0.1"
-      }
-    },
-    "strip-ansi-cjs": {
-      "version": "npm:strip-ansi@6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^5.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        }
-      }
-    },
-    "strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true
-    },
-    "supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "requires": {
-        "has-flag": "^3.0.0"
-      }
-    },
-    "supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true
-    },
-    "table-layout": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-3.0.2.tgz",
-      "integrity": "sha512-rpyNZYRw+/C+dYkcQ3Pr+rLxW4CfHpXjPDnG7lYhdRoUcZTUt+KEsX+94RGp/aVp/MQU35JCITv2T/beY4m+hw==",
-      "dev": true,
-      "requires": {
-        "@75lb/deep-merge": "^1.1.1",
-        "array-back": "^6.2.2",
-        "command-line-args": "^5.2.1",
-        "command-line-usage": "^7.0.0",
-        "stream-read-all": "^3.0.1",
-        "typical": "^7.1.1",
-        "wordwrapjs": "^5.1.0"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "6.2.2",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
-          "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
-          "dev": true
-        },
-        "typical": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/typical/-/typical-7.1.1.tgz",
-          "integrity": "sha512-T+tKVNs6Wu7IWiAce5BgMd7OZfNYUndHwc5MknN+UHOudi7sGZzuHdCadllRuqJ3fPtgFtIH9+lt9qRv6lmpfA==",
-          "dev": true
-        }
-      }
-    },
-    "tar-fs": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
-      "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
-      "dev": true,
-      "requires": {
-        "bare-fs": "^2.1.1",
-        "bare-path": "^2.1.0",
-        "pump": "^3.0.0",
-        "tar-stream": "^3.1.5"
-      },
-      "dependencies": {
-        "tar-stream": {
-          "version": "3.1.7",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-          "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
-          "dev": true,
-          "requires": {
-            "b4a": "^1.6.4",
-            "fast-fifo": "^1.2.0",
-            "streamx": "^2.15.0"
-          }
-        }
-      }
-    },
-    "tar-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
-      "dev": true,
-      "requires": {
-        "bl": "^1.0.0",
-        "buffer-alloc": "^1.2.0",
-        "end-of-stream": "^1.0.0",
-        "fs-constants": "^1.0.0",
-        "readable-stream": "^2.3.0",
-        "to-buffer": "^1.1.1",
-        "xtend": "^4.0.0"
-      }
-    },
-    "terser": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.0.tgz",
-      "integrity": "sha512-Q1JFAoUKE5IMfI4Z/lkE/E6+SwgzO+x4tq4v1AyBLRj8VSYvRO6A/rQrPg1yud4g0En9EKI1TvFRF2tQFcoUkg==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true
-        }
-      }
-    },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "dev": true
-    },
-    "to-buffer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-      "dev": true
-    },
-    "to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "requires": {
-        "is-number": "^7.0.0"
-      }
-    },
-    "toidentifier": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "dev": true
-    },
-    "tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-      "dev": true,
-      "requires": {
-        "punycode": "^2.1.1"
-      }
-    },
-    "tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
-    "tsscmp": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
-      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
-      "dev": true
-    },
-    "tunnel": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-      "dev": true
-    },
-    "type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
-    },
-    "type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true
-    },
-    "type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "dev": true,
-      "requires": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
-      }
-    },
-    "typical": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
-      "dev": true
-    },
-    "ua-parser-js": {
-      "version": "1.0.37",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.37.tgz",
-      "integrity": "sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ==",
-      "dev": true
-    },
-    "unbzip2-stream": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-      "dev": true,
-      "requires": {
-        "buffer": "^5.2.1",
-        "through": "^2.3.8"
-      }
-    },
-    "undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
-    },
-    "universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true
-    },
-    "unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "dev": true
-    },
-    "unzipper": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.11.6.tgz",
-      "integrity": "sha512-anERl79akvqLbAxfjIFe4hK0wsi0fH4uGLwNEl4QEnG+KKs3QQeApYgOS/f6vH2EdACUlZg35psmd/3xL2duFQ==",
-      "dev": true,
-      "requires": {
-        "big-integer": "^1.6.17",
-        "bluebird": "~3.4.1",
-        "duplexer2": "~0.1.4",
-        "fstream": "^1.0.12",
-        "graceful-fs": "^4.2.2"
-      }
-    },
-    "upper-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
-      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "upper-case-first": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
-      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "urlpattern-polyfill": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
-      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
-      "dev": true
-    },
-    "userhome": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/userhome/-/userhome-1.0.0.tgz",
-      "integrity": "sha512-ayFKY3H+Pwfy4W98yPdtH1VqH4psDeyW8lYYFzfecR9d6hqLpqhecktvYR3SEEXt7vG0S1JEpciI3g94pMErig==",
-      "dev": true
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
-    },
-    "v8-to-istanbul": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
-      "integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/trace-mapping": "^0.3.12",
-        "@types/istanbul-lib-coverage": "^2.0.1",
-        "convert-source-map": "^2.0.0"
-      }
-    },
-    "vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "dev": true
-    },
-    "wait-port": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/wait-port/-/wait-port-1.1.0.tgz",
-      "integrity": "sha512-3e04qkoN3LxTMLakdqeWth8nih8usyg+sf1Bgdf9wwUkp05iuK1eSY/QpLvscT/+F/gA89+LpUmmgBtesbqI2Q==",
-      "dev": true,
-      "requires": {
-        "chalk": "^4.1.2",
-        "commander": "^9.3.0",
-        "debug": "^4.3.4"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "commander": {
-          "version": "9.5.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-          "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
-    "web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "dev": true
-    },
-    "webdriver": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-8.37.0.tgz",
-      "integrity": "sha512-B2PxFdSpwkVczqerTmu0wUSURxozmk1rs/RUm5FVrsH/qKtKQjkbg21yZr5epoZAwiCYw+F3HaPGChGL74XR8w==",
-      "dev": true,
-      "requires": {
-        "@types/node": "^20.1.0",
-        "@types/ws": "^8.5.3",
-        "@wdio/config": "8.37.0",
-        "@wdio/logger": "8.28.0",
-        "@wdio/protocols": "8.32.0",
-        "@wdio/types": "8.37.0",
-        "@wdio/utils": "8.37.0",
-        "deepmerge-ts": "^5.1.0",
-        "got": "^12.6.1",
-        "ky": "^0.33.0",
-        "ws": "^8.8.0"
-      },
-      "dependencies": {
-        "@sindresorhus/is": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
-          "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
-          "dev": true
-        },
-        "@szmarczak/http-timer": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
-          "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
-          "dev": true,
-          "requires": {
-            "defer-to-connect": "^2.0.1"
-          }
-        },
-        "@types/ws": {
-          "version": "8.5.12",
-          "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
-          "integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
-          "dev": true,
-          "requires": {
-            "@types/node": "*"
-          }
-        },
-        "cacheable-lookup": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
-          "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
-          "dev": true
-        },
-        "cacheable-request": {
-          "version": "10.2.14",
-          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
-          "integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
-          "dev": true,
-          "requires": {
-            "@types/http-cache-semantics": "^4.0.2",
-            "get-stream": "^6.0.1",
-            "http-cache-semantics": "^4.1.1",
-            "keyv": "^4.5.3",
-            "mimic-response": "^4.0.0",
-            "normalize-url": "^8.0.0",
-            "responselike": "^3.0.0"
-          }
-        },
-        "got": {
-          "version": "12.6.1",
-          "resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
-          "integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
-          "dev": true,
-          "requires": {
-            "@sindresorhus/is": "^5.2.0",
-            "@szmarczak/http-timer": "^5.0.1",
-            "cacheable-lookup": "^7.0.0",
-            "cacheable-request": "^10.2.8",
-            "decompress-response": "^6.0.0",
-            "form-data-encoder": "^2.1.2",
-            "get-stream": "^6.0.1",
-            "http2-wrapper": "^2.1.10",
-            "lowercase-keys": "^3.0.0",
-            "p-cancelable": "^3.0.0",
-            "responselike": "^3.0.0"
-          }
-        },
-        "http2-wrapper": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
-          "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
-          "dev": true,
-          "requires": {
-            "quick-lru": "^5.1.1",
-            "resolve-alpn": "^1.2.0"
-          }
-        },
-        "lowercase-keys": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-          "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
-          "dev": true
-        },
-        "mimic-response": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
-          "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
-          "dev": true
-        },
-        "normalize-url": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.1.tgz",
-          "integrity": "sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==",
-          "dev": true
-        },
-        "p-cancelable": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
-          "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
-          "dev": true
-        },
-        "responselike": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
-          "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
-          "dev": true,
-          "requires": {
-            "lowercase-keys": "^3.0.0"
-          }
-        },
-        "ws": {
-          "version": "8.18.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-          "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-          "dev": true,
-          "requires": {}
-        }
-      }
-    },
-    "webdriverio": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-8.37.0.tgz",
-      "integrity": "sha512-GaL+12fiAdkFJyx4n30tfaJUpPwVELgEsfwumeQLFcqU3ERrM5W1c1QvEzE03oMT4/5NgzPy0lIwcec9pftRWg==",
-      "dev": true,
-      "requires": {
-        "@types/node": "^20.1.0",
-        "@wdio/config": "8.37.0",
-        "@wdio/logger": "8.28.0",
-        "@wdio/protocols": "8.32.0",
-        "@wdio/repl": "8.24.12",
-        "@wdio/types": "8.37.0",
-        "@wdio/utils": "8.37.0",
-        "archiver": "^7.0.0",
-        "aria-query": "^5.0.0",
-        "css-shorthand-properties": "^1.1.1",
-        "css-value": "^0.0.1",
-        "devtools-protocol": "^0.0.1302984",
-        "grapheme-splitter": "^1.0.2",
-        "import-meta-resolve": "^4.0.0",
-        "is-plain-obj": "^4.1.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.zip": "^4.2.0",
-        "minimatch": "^9.0.0",
-        "puppeteer-core": "^20.9.0",
-        "query-selector-shadow-dom": "^1.0.0",
-        "resq": "^1.9.1",
-        "rgb2hex": "0.2.5",
-        "serialize-error": "^11.0.1",
-        "webdriver": "8.37.0"
-      },
-      "dependencies": {
-        "@puppeteer/browsers": {
-          "version": "1.4.6",
-          "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.4.6.tgz",
-          "integrity": "sha512-x4BEjr2SjOPowNeiguzjozQbsc6h437ovD/wu+JpaenxVLm3jkgzHY2xOslMTp50HoTvQreMjiexiGQw1sqZlQ==",
-          "dev": true,
-          "requires": {
-            "debug": "4.3.4",
-            "extract-zip": "2.0.1",
-            "progress": "2.0.3",
-            "proxy-agent": "6.3.0",
-            "tar-fs": "3.0.4",
-            "unbzip2-stream": "1.4.3",
-            "yargs": "17.7.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        },
-        "chromium-bidi": {
-          "version": "0.4.16",
-          "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.16.tgz",
-          "integrity": "sha512-7ZbXdWERxRxSwo3txsBjjmc/NLxqb1Bk30mRb0BMS4YIaiV6zvKZqL/UAH+DdqcDYayDWk2n/y8klkBDODrPvA==",
-          "dev": true,
-          "requires": {
-            "mitt": "3.0.0"
-          }
-        },
-        "devtools-protocol": {
-          "version": "0.0.1302984",
-          "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1302984.tgz",
-          "integrity": "sha512-Rgh2Sk5fUSCtEx4QGH9iwTyECdFPySG2nlz5J8guGh2Wlha6uzSOCq/DCEC8faHlLaMPZJMuZ4ovgcX4LvOkKA==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "7.18.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-          "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-          "dev": true
-        },
-        "mitt": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
-          "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
-          "dev": true
-        },
-        "proxy-agent": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.0.tgz",
-          "integrity": "sha512-0LdR757eTj/JfuU7TL2YCuAZnxWXu3tkJbg4Oq3geW/qFNT/32T0sp2HnZ9O0lMR4q3vwAt0+xCA8SR0WAD0og==",
-          "dev": true,
-          "requires": {
-            "agent-base": "^7.0.2",
-            "debug": "^4.3.4",
-            "http-proxy-agent": "^7.0.0",
-            "https-proxy-agent": "^7.0.0",
-            "lru-cache": "^7.14.1",
-            "pac-proxy-agent": "^7.0.0",
-            "proxy-from-env": "^1.1.0",
-            "socks-proxy-agent": "^8.0.1"
-          }
-        },
-        "puppeteer-core": {
-          "version": "20.9.0",
-          "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.9.0.tgz",
-          "integrity": "sha512-H9fYZQzMTRrkboEfPmf7m3CLDN6JvbxXA3qTtS+dFt27tR+CsFHzPsT6pzp6lYL6bJbAPaR0HaPO6uSi+F94Pg==",
-          "dev": true,
-          "requires": {
-            "@puppeteer/browsers": "1.4.6",
-            "chromium-bidi": "0.4.16",
-            "cross-fetch": "4.0.0",
-            "debug": "4.3.4",
-            "devtools-protocol": "0.0.1147663",
-            "ws": "8.13.0"
-          },
-          "dependencies": {
-            "devtools-protocol": {
-              "version": "0.0.1147663",
-              "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1147663.tgz",
-              "integrity": "sha512-hyWmRrexdhbZ1tcJUGpO95ivbRhWXz++F4Ko+n21AY5PNln2ovoJw+8ZMNDTtip+CNFQfrtLVh/w4009dXO/eQ==",
-              "dev": true
-            }
-          }
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        },
-        "tar-fs": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
-          "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
-          "dev": true,
-          "requires": {
-            "mkdirp-classic": "^0.5.2",
-            "pump": "^3.0.0",
-            "tar-stream": "^3.1.5"
-          }
-        },
-        "tar-stream": {
-          "version": "3.1.7",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-          "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
-          "dev": true,
-          "requires": {
-            "b4a": "^1.6.4",
-            "fast-fifo": "^1.2.0",
-            "streamx": "^2.15.0"
-          }
-        },
-        "ws": {
-          "version": "8.13.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-          "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-          "dev": true,
-          "requires": {}
-        },
-        "yargs": {
-          "version": "17.7.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-          "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
-          "dev": true,
-          "requires": {
-            "cliui": "^8.0.1",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.3",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^21.1.1"
-          }
-        }
-      }
-    },
-    "webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true
-    },
-    "whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-      "dev": true,
-      "requires": {
-        "tr46": "^3.0.0",
-        "webidl-conversions": "^7.0.0"
-      }
-    },
-    "which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "requires": {
-        "isexe": "^2.0.0"
-      }
-    },
-    "wordwrapjs": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.0.tgz",
-      "integrity": "sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==",
-      "dev": true
-    },
-    "wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-          "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-          "dev": true
-        }
-      }
-    },
-    "wrap-ansi-cjs": {
-      "version": "npm:wrap-ansi@7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        }
-      }
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
-    },
-    "ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "dev": true,
-      "requires": {}
-    },
-    "xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true
-    },
-    "y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
-    "yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
-      "requires": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        }
-      }
-    },
-    "yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true
-    },
-    "yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
-      "requires": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
-    "yazl": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
-      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
-      "dev": true,
-      "requires": {
-        "buffer-crc32": "~0.2.3"
-      }
-    },
-    "ylru": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.4.0.tgz",
-      "integrity": "sha512-2OQsPNEmBCvXuFlIni/a+Rn+R2pHW9INm0BxXJ4hVDA8TirqMj+J/Rp9ItLatT/5pZqWwefVrTQcHpixsxnVlA==",
-      "dev": true
-    },
-    "zip-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
-      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
-      "dev": true,
-      "requires": {
-        "archiver-utils": "^5.0.0",
-        "compress-commons": "^6.0.2",
-        "readable-stream": "^4.0.0"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
-        "readable-stream": {
-          "version": "4.5.2",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-          "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-          "dev": true,
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^6.0.3",
-            "events": "^3.3.0",
-            "process": "^0.11.10",
-            "string_decoder": "^1.3.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
-        }
-      }
-    },
-    "zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
-      "dev": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -876,19 +876,19 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.3.tgz",
-      "integrity": "sha512-bJ0UBsk0ESOs6RFcLXOt99a3yTDcOKlzfjad+rhFwdaG1Lu/Wzq58GHYCDTlZ9z6mldf4g+NTb+TXEfe0PpnsQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.3.0.tgz",
+      "integrity": "sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==",
       "dev": true,
       "dependencies": {
-        "debug": "4.3.4",
-        "extract-zip": "2.0.1",
-        "progress": "2.0.3",
-        "proxy-agent": "6.4.0",
-        "semver": "7.6.0",
-        "tar-fs": "3.0.5",
-        "unbzip2-stream": "1.4.3",
-        "yargs": "17.7.2"
+        "debug": "^4.3.5",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.4.0",
+        "semver": "^7.6.3",
+        "tar-fs": "^3.0.6",
+        "unbzip2-stream": "^1.4.3",
+        "yargs": "^17.7.2"
       },
       "bin": {
         "browsers": "lib/cjs/main-cli.js"
@@ -897,31 +897,21 @@
         "node": ">=18"
       }
     },
-    "node_modules/@puppeteer/browsers/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+    "node_modules/@puppeteer/browsers/node_modules/debug": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
       "dev": true,
       "dependencies": {
-        "yallist": "^4.0.0"
+        "ms": "2.1.2"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
+        "node": ">=6.0"
       },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -3045,9 +3035,9 @@
       }
     },
     "node_modules/@web/test-runner-core": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-core/-/test-runner-core-0.13.2.tgz",
-      "integrity": "sha512-G0D3mv9jvR+5xILENchPP9v1ZjBf3QVlzarMLR5jedCNbgntzcayF0LeW5wh5uyafGZJH28cYm9jGrJvGipoPQ==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-core/-/test-runner-core-0.13.3.tgz",
+      "integrity": "sha512-ilDqF/v2sj0sD69FNSIDT7uw4M1yTVedLBt32/lXy3MMi6suCM7m/ZlhsBy8PXhf879WMvzBOl/vhJBpEMB9vA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.11",
@@ -3066,7 +3056,7 @@
         "debounce": "^1.2.0",
         "dependency-graph": "^0.11.0",
         "globby": "^11.0.1",
-        "ip": "^2.0.1",
+        "internal-ip": "^6.2.0",
         "istanbul-lib-coverage": "^3.0.0",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-reports": "^3.0.2",
@@ -3364,9 +3354,9 @@
       }
     },
     "node_modules/archiver/node_modules/async": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true
     },
     "node_modules/archiver/node_modules/buffer": {
@@ -4060,14 +4050,14 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.19.tgz",
-      "integrity": "sha512-UA6zL77b7RYCjJkZBsZ0wlvCTD+jTjllZ8f6wdO4buevXgTZYjV+XLB9CiEa2OuuTGGTLnI7eN9I60YxuALGQg==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.3.tgz",
+      "integrity": "sha512-qXlsCmpCZJAnoTYI83Iu6EdYQpMYdVkCfq08KDh2pmlVqK5t5IA9mGs4/LwCwp4fqisSOMXZxP3HIh8w8aRn0A==",
       "dev": true,
       "dependencies": {
         "mitt": "3.0.1",
         "urlpattern-polyfill": "10.0.0",
-        "zod": "3.22.4"
+        "zod": "3.23.8"
       },
       "peerDependencies": {
         "devtools-protocol": "*"
@@ -4778,6 +4768,18 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/default-gateway": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
+      "integrity": "sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==",
+      "dev": true,
+      "dependencies": {
+        "execa": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
@@ -4892,9 +4894,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1286932",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1286932.tgz",
-      "integrity": "sha512-wu58HMQll9voDjR4NlPyoDEw1syfzaBNHymMMZ/QOXiHRNluOnDgu9hp1yHOKYoMlxCh4lSSiugLITe6Fvu1eA==",
+      "version": "0.0.1312386",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
+      "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
       "dev": true
     },
     "node_modules/diff": {
@@ -5245,6 +5247,35 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -5484,9 +5515,9 @@
       "dev": true
     },
     "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -5620,31 +5651,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/geckodriver/node_modules/tar-fs": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
-      "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
-      "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0",
-        "tar-stream": "^3.1.5"
-      },
-      "optionalDependencies": {
-        "bare-fs": "^2.1.1",
-        "bare-path": "^2.1.0"
-      }
-    },
-    "node_modules/geckodriver/node_modules/tar-stream": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
-      "dev": true,
-      "dependencies": {
-        "b4a": "^1.6.4",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
-      }
-    },
     "node_modules/geckodriver/node_modules/which": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
@@ -5756,22 +5762,20 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.3.16",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.16.tgz",
-      "integrity": "sha512-JDKXl1DiuuHJ6fVS2FXjownaavciiHNUU4mOvV/B793RLh05vZL1rcPnCSaOgv1hDT6RDlY7AB7ZUvFYAtPgAw==",
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
       "dev": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.1",
-        "minipass": "^7.0.4",
-        "path-scurry": "^1.11.0"
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -6060,6 +6064,15 @@
         "node": ">= 14"
       }
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -6137,6 +6150,24 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "node_modules/internal-ip": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-6.2.0.tgz",
+      "integrity": "sha512-D8WGsR6yDt8uq7vDMu7mjcR+yRMm3dW8yufyChmszWRjcSHuxLBkR3GdS2HZAjodsaGuCvXeEJpueisXJULghg==",
+      "dev": true,
+      "dependencies": {
+        "default-gateway": "^6.0.0",
+        "ipaddr.js": "^1.9.1",
+        "is-ip": "^3.1.0",
+        "p-event": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/internal-ip?sponsor=1"
+      }
+    },
     "node_modules/ip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
@@ -6154,6 +6185,24 @@
       },
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/ip-regex": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-binary-path": {
@@ -6253,6 +6302,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-ip": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+      "dev": true,
+      "dependencies": {
+        "ip-regex": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-module": {
@@ -7105,6 +7166,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -7173,9 +7240,9 @@
       "dev": true
     },
     "node_modules/minimatch": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -7197,9 +7264,9 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.1.tgz",
-      "integrity": "sha512-UZ7eQ+h8ywIRAW1hIEl2AqdwzJucU/Kp59+8kkZeSvafXhZjul247BvIJjEVFVeON6d7lM46XX1HXCduKAS8VA==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -7309,12 +7376,12 @@
       }
     },
     "node_modules/nise/node_modules/@sinonjs/fake-timers": {
-      "version": "11.2.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
-      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.3.1.tgz",
+      "integrity": "sha512-EVJO7nW5M/F5Tur0Rf2z/QoMo+1Ia963RiMtapiQrEWvY0iBUvADo8Beegwjpnle5BHkyHuoxSTW3jF43H1XRA==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/commons": "^3.0.0"
+        "@sinonjs/commons": "^3.0.1"
       }
     },
     "node_modules/no-case": {
@@ -7394,6 +7461,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
@@ -7471,6 +7550,42 @@
         "node": ">=8"
       }
     },
+    "node_modules/p-event": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
+      "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
+      "dev": true,
+      "dependencies": {
+        "p-timeout": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dev": true,
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/pac-proxy-agent": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.1.tgz",
@@ -7502,6 +7617,12 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+      "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+      "dev": true
     },
     "node_modules/param-case": {
       "version": "3.0.4",
@@ -7589,13 +7710,10 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
-      "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
-      "dev": true,
-      "engines": {
-        "node": "14 || >=16.14"
-      }
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
     },
     "node_modules/path-to-regexp": {
       "version": "6.2.2",
@@ -7695,20 +7813,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pngjs": {
@@ -7848,25 +7952,42 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "22.9.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.9.0.tgz",
-      "integrity": "sha512-Q2SYVZ1SIE7jCd/Pp+1/mNLFtdJfGvAF+CqOTDG8HcCNCiBvoXfopXfOfMHQ/FueXhGfJW/I6DartWv6QzpNGg==",
+      "version": "22.15.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.15.0.tgz",
+      "integrity": "sha512-cHArnywCiAAVXa3t4GGL2vttNxh7GqXtIYGym99egkNJ3oG//wL9LkvO4WE8W1TJe95t1F1ocu9X4xWaGsOKOA==",
       "dev": true,
       "dependencies": {
-        "@puppeteer/browsers": "2.2.3",
-        "chromium-bidi": "0.5.19",
-        "debug": "4.3.4",
-        "devtools-protocol": "0.0.1286932",
-        "ws": "8.17.0"
+        "@puppeteer/browsers": "2.3.0",
+        "chromium-bidi": "0.6.3",
+        "debug": "^4.3.6",
+        "devtools-protocol": "0.0.1312386",
+        "ws": "^8.18.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
+    "node_modules/puppeteer-core/node_modules/debug": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/puppeteer-core/node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -8211,18 +8332,15 @@
       "dev": true
     },
     "node_modules/rimraf": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.7.tgz",
-      "integrity": "sha512-nV6YcJo5wbLW77m+8KjH8aB/7/rxQy9SZ0HY5shnwULfS+9nmTtVXAJET5NdZmCzA4fPI/Hm1wo/Po/4mopOdg==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
       "dev": true,
       "dependencies": {
         "glob": "^10.3.7"
       },
       "bin": {
         "rimraf": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -8338,9 +8456,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -8861,6 +8979,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -8925,9 +9052,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.5.tgz",
-      "integrity": "sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
+      "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
       "dev": true,
       "dependencies": {
         "pump": "^3.0.0",
@@ -9387,9 +9514,9 @@
       }
     },
     "node_modules/webdriver/node_modules/@types/ws": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
-      "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
+      "integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -9521,9 +9648,9 @@
       }
     },
     "node_modules/webdriver/node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -9972,9 +10099,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
@@ -10176,9 +10303,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -10318,7 +10445,7 @@
         "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
         "@vaadin/vaadin-development-mode-detector": "^2.0.0",
         "@vaadin/vaadin-usage-statistics": "^2.1.0",
-        "lit": "^2.0.0"
+        "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "packages/confirm-dialog": {
@@ -10457,7 +10584,7 @@
         "@polymer/polymer": "^3.0.0",
         "@scoped-vaadin/component-base": "^23.4.1",
         "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "lit": "^2.0.0"
+        "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "packages/field-highlighter": {
@@ -10472,7 +10599,7 @@
         "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
         "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
         "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-        "lit": "^2.0.0"
+        "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "packages/form-layout": {
@@ -10528,7 +10655,7 @@
         "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
         "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
         "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-        "lit": "^2.0.0"
+        "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "packages/icons": {
@@ -10604,7 +10731,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "lit": "^2.0.0"
+        "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "packages/login": {
@@ -10699,7 +10826,7 @@
         "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
         "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
         "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-        "lit": "^2.0.0"
+        "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "packages/number-field": {
@@ -10754,7 +10881,7 @@
         "@polymer/polymer": "^3.0.0",
         "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
         "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-        "lit": "^2.0.0"
+        "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "packages/progress-bar": {
@@ -10979,7 +11106,7 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "lit": "^2.0.0"
+        "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "packages/vertical-layout": {
@@ -11651,37 +11778,28 @@
       }
     },
     "@puppeteer/browsers": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.3.tgz",
-      "integrity": "sha512-bJ0UBsk0ESOs6RFcLXOt99a3yTDcOKlzfjad+rhFwdaG1Lu/Wzq58GHYCDTlZ9z6mldf4g+NTb+TXEfe0PpnsQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.3.0.tgz",
+      "integrity": "sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==",
       "dev": true,
       "requires": {
-        "debug": "4.3.4",
-        "extract-zip": "2.0.1",
-        "progress": "2.0.3",
-        "proxy-agent": "6.4.0",
-        "semver": "7.6.0",
-        "tar-fs": "3.0.5",
-        "unbzip2-stream": "1.4.3",
-        "yargs": "17.7.2"
+        "debug": "^4.3.5",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.4.0",
+        "semver": "^7.6.3",
+        "tar-fs": "^3.0.6",
+        "unbzip2-stream": "^1.4.3",
+        "yargs": "^17.7.2"
       },
       "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+        "debug": {
+          "version": "4.3.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+          "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
           "dev": true,
           "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.6.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-          "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
+            "ms": "2.1.2"
           }
         }
       }
@@ -11939,7 +12057,7 @@
         "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
         "@vaadin/vaadin-development-mode-detector": "^2.0.0",
         "@vaadin/vaadin-usage-statistics": "^2.1.0",
-        "lit": "^2.0.0"
+        "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "@scoped-vaadin/confirm-dialog": {
@@ -12060,7 +12178,7 @@
         "@polymer/polymer": "^3.0.0",
         "@scoped-vaadin/component-base": "^23.4.1",
         "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "lit": "^2.0.0"
+        "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "@scoped-vaadin/field-highlighter": {
@@ -12073,7 +12191,7 @@
         "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
         "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
         "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-        "lit": "^2.0.0"
+        "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "@scoped-vaadin/form-layout": {
@@ -12121,7 +12239,7 @@
         "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
         "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
         "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-        "lit": "^2.0.0"
+        "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "@scoped-vaadin/icons": {
@@ -12188,7 +12306,7 @@
       "version": "file:packages/lit-renderer",
       "requires": {
         "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "lit": "^2.0.0"
+        "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "@scoped-vaadin/login": {
@@ -12271,7 +12389,7 @@
         "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
         "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
         "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-        "lit": "^2.0.0"
+        "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "@scoped-vaadin/number-field": {
@@ -12318,7 +12436,7 @@
         "@polymer/polymer": "^3.0.0",
         "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
         "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-        "lit": "^2.0.0"
+        "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "@scoped-vaadin/progress-bar": {
@@ -12573,7 +12691,7 @@
       "requires": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1",
-        "lit": "^2.0.0"
+        "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "@scoped-vaadin/vertical-layout": {
@@ -14146,9 +14264,9 @@
       }
     },
     "@web/test-runner-core": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-core/-/test-runner-core-0.13.2.tgz",
-      "integrity": "sha512-G0D3mv9jvR+5xILENchPP9v1ZjBf3QVlzarMLR5jedCNbgntzcayF0LeW5wh5uyafGZJH28cYm9jGrJvGipoPQ==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-core/-/test-runner-core-0.13.3.tgz",
+      "integrity": "sha512-ilDqF/v2sj0sD69FNSIDT7uw4M1yTVedLBt32/lXy3MMi6suCM7m/ZlhsBy8PXhf879WMvzBOl/vhJBpEMB9vA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.11",
@@ -14167,7 +14285,7 @@
         "debounce": "^1.2.0",
         "dependency-graph": "^0.11.0",
         "globby": "^11.0.1",
-        "ip": "^2.0.1",
+        "internal-ip": "^6.2.0",
         "istanbul-lib-coverage": "^3.0.0",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-reports": "^3.0.2",
@@ -14341,9 +14459,9 @@
       },
       "dependencies": {
         "async": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-          "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+          "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
           "dev": true
         },
         "buffer": {
@@ -14921,14 +15039,14 @@
       }
     },
     "chromium-bidi": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.19.tgz",
-      "integrity": "sha512-UA6zL77b7RYCjJkZBsZ0wlvCTD+jTjllZ8f6wdO4buevXgTZYjV+XLB9CiEa2OuuTGGTLnI7eN9I60YxuALGQg==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.3.tgz",
+      "integrity": "sha512-qXlsCmpCZJAnoTYI83Iu6EdYQpMYdVkCfq08KDh2pmlVqK5t5IA9mGs4/LwCwp4fqisSOMXZxP3HIh8w8aRn0A==",
       "dev": true,
       "requires": {
         "mitt": "3.0.1",
         "urlpattern-polyfill": "10.0.0",
-        "zod": "3.22.4"
+        "zod": "3.23.8"
       }
     },
     "clean-css": {
@@ -15469,6 +15587,15 @@
       "integrity": "sha512-eS8dRJOckyo9maw9Tu5O5RUi/4inFLrnoLkBe3cPfDMx3WZioXtmOew4TXQaxq7Rhl4xjDtR7c6x8nNTxOvbFw==",
       "dev": true
     },
+    "default-gateway": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
+      "integrity": "sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==",
+      "dev": true,
+      "requires": {
+        "execa": "^5.0.0"
+      }
+    },
     "defer-to-connect": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
@@ -15546,9 +15673,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.1286932",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1286932.tgz",
-      "integrity": "sha512-wu58HMQll9voDjR4NlPyoDEw1syfzaBNHymMMZ/QOXiHRNluOnDgu9hp1yHOKYoMlxCh4lSSiugLITe6Fvu1eA==",
+      "version": "0.0.1312386",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
+      "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
       "dev": true
     },
     "diff": {
@@ -15810,6 +15937,31 @@
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "dev": true
     },
+    "execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "dependencies": {
+        "signal-exit": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+          "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+          "dev": true
+        }
+      }
+    },
     "extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -15991,9 +16143,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "optional": true
     },
@@ -16090,29 +16242,6 @@
           "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
           "dev": true
         },
-        "tar-fs": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
-          "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
-          "dev": true,
-          "requires": {
-            "bare-fs": "^2.1.1",
-            "bare-path": "^2.1.0",
-            "pump": "^3.0.0",
-            "tar-stream": "^3.1.5"
-          }
-        },
-        "tar-stream": {
-          "version": "3.1.7",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-          "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
-          "dev": true,
-          "requires": {
-            "b4a": "^1.6.4",
-            "fast-fifo": "^1.2.0",
-            "streamx": "^2.15.0"
-          }
-        },
         "which": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
@@ -16190,16 +16319,17 @@
       }
     },
     "glob": {
-      "version": "10.3.16",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.16.tgz",
-      "integrity": "sha512-JDKXl1DiuuHJ6fVS2FXjownaavciiHNUU4mOvV/B793RLh05vZL1rcPnCSaOgv1hDT6RDlY7AB7ZUvFYAtPgAw==",
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
       "dev": true,
       "requires": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.1",
-        "minipass": "^7.0.4",
-        "path-scurry": "^1.11.0"
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       }
     },
     "glob-parent": {
@@ -16418,6 +16548,12 @@
         "debug": "4"
       }
     },
+    "human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -16467,6 +16603,18 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "internal-ip": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-6.2.0.tgz",
+      "integrity": "sha512-D8WGsR6yDt8uq7vDMu7mjcR+yRMm3dW8yufyChmszWRjcSHuxLBkR3GdS2HZAjodsaGuCvXeEJpueisXJULghg==",
+      "dev": true,
+      "requires": {
+        "default-gateway": "^6.0.0",
+        "ipaddr.js": "^1.9.1",
+        "is-ip": "^3.1.0",
+        "p-event": "^4.2.0"
+      }
+    },
     "ip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
@@ -16482,6 +16630,18 @@
         "jsbn": "1.1.0",
         "sprintf-js": "^1.1.3"
       }
+    },
+    "ip-regex": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+      "dev": true
+    },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -16544,6 +16704,15 @@
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
+      }
+    },
+    "is-ip": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+      "dev": true,
+      "requires": {
+        "ip-regex": "^4.0.0"
       }
     },
     "is-module": {
@@ -17142,6 +17311,12 @@
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "dev": true
     },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -17192,9 +17367,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
       "requires": {
         "brace-expansion": "^2.0.1"
@@ -17207,9 +17382,9 @@
       "dev": true
     },
     "minipass": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.1.tgz",
-      "integrity": "sha512-UZ7eQ+h8ywIRAW1hIEl2AqdwzJucU/Kp59+8kkZeSvafXhZjul247BvIJjEVFVeON6d7lM46XX1HXCduKAS8VA==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "dev": true
     },
     "mitt": {
@@ -17289,12 +17464,12 @@
           }
         },
         "@sinonjs/fake-timers": {
-          "version": "11.2.2",
-          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
-          "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+          "version": "11.3.1",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.3.1.tgz",
+          "integrity": "sha512-EVJO7nW5M/F5Tur0Rf2z/QoMo+1Ia963RiMtapiQrEWvY0iBUvADo8Beegwjpnle5BHkyHuoxSTW3jF43H1XRA==",
           "dev": true,
           "requires": {
-            "@sinonjs/commons": "^3.0.0"
+            "@sinonjs/commons": "^3.0.1"
           }
         }
       }
@@ -17345,6 +17520,15 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
       "dev": true
+    },
+    "npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.0.0"
+      }
     },
     "object-inspect": {
       "version": "1.13.1",
@@ -17402,6 +17586,30 @@
       "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
       "dev": true
     },
+    "p-event": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
+      "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
+      "dev": true,
+      "requires": {
+        "p-timeout": "^3.1.0"
+      }
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "dev": true
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dev": true,
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
+    },
     "pac-proxy-agent": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.1.tgz",
@@ -17427,6 +17635,12 @@
         "degenerator": "^5.0.0",
         "netmask": "^2.0.2"
       }
+    },
+    "package-json-from-dist": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+      "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+      "dev": true
     },
     "param-case": {
       "version": "3.0.4",
@@ -17499,9 +17713,9 @@
       },
       "dependencies": {
         "lru-cache": {
-          "version": "10.2.2",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
-          "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
+          "version": "10.4.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+          "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
           "dev": true
         }
       }
@@ -17568,15 +17782,6 @@
       "requires": {
         "fsevents": "2.3.2",
         "playwright-core": "1.44.1"
-      },
-      "dependencies": {
-        "fsevents": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-          "dev": true,
-          "optional": true
-        }
       }
     },
     "playwright-core": {
@@ -17693,22 +17898,31 @@
       "dev": true
     },
     "puppeteer-core": {
-      "version": "22.9.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.9.0.tgz",
-      "integrity": "sha512-Q2SYVZ1SIE7jCd/Pp+1/mNLFtdJfGvAF+CqOTDG8HcCNCiBvoXfopXfOfMHQ/FueXhGfJW/I6DartWv6QzpNGg==",
+      "version": "22.15.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.15.0.tgz",
+      "integrity": "sha512-cHArnywCiAAVXa3t4GGL2vttNxh7GqXtIYGym99egkNJ3oG//wL9LkvO4WE8W1TJe95t1F1ocu9X4xWaGsOKOA==",
       "dev": true,
       "requires": {
-        "@puppeteer/browsers": "2.2.3",
-        "chromium-bidi": "0.5.19",
-        "debug": "4.3.4",
-        "devtools-protocol": "0.0.1286932",
-        "ws": "8.17.0"
+        "@puppeteer/browsers": "2.3.0",
+        "chromium-bidi": "0.6.3",
+        "debug": "^4.3.6",
+        "devtools-protocol": "0.0.1312386",
+        "ws": "^8.18.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "4.3.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+          "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
         "ws": {
-          "version": "8.17.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-          "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+          "version": "8.18.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+          "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
           "dev": true,
           "requires": {}
         }
@@ -17970,9 +18184,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.7.tgz",
-      "integrity": "sha512-nV6YcJo5wbLW77m+8KjH8aB/7/rxQy9SZ0HY5shnwULfS+9nmTtVXAJET5NdZmCzA4fPI/Hm1wo/Po/4mopOdg==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
       "dev": true,
       "requires": {
         "glob": "^10.3.7"
@@ -18048,9 +18262,9 @@
       }
     },
     "semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true
     },
     "sentence-case": {
@@ -18434,6 +18648,12 @@
         }
       }
     },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -18479,9 +18699,9 @@
       }
     },
     "tar-fs": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.5.tgz",
-      "integrity": "sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
+      "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
       "dev": true,
       "requires": {
         "bare-fs": "^2.1.1",
@@ -18829,9 +19049,9 @@
           }
         },
         "@types/ws": {
-          "version": "8.5.10",
-          "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
-          "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
+          "version": "8.5.12",
+          "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
+          "integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
           "dev": true,
           "requires": {
             "@types/node": "*"
@@ -18921,9 +19141,9 @@
           }
         },
         "ws": {
-          "version": "8.17.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-          "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+          "version": "8.18.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+          "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
           "dev": true,
           "requires": {}
         }
@@ -19245,9 +19465,9 @@
       "dev": true
     },
     "ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
       "requires": {}
     },
@@ -19395,9 +19615,9 @@
       }
     },
     "zod": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "name": "@robrez/scoped-vaadin-web-components",
   "type": "module",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "name": "@robrez/scoped-vaadin-web-components",
   "type": "module",
   "private": true,

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/accordion",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,11 +40,11 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/details": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/details": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/accordion",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,11 +40,11 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/details": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/details": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/app-layout/package.json
+++ b/packages/app-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/app-layout",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,11 +40,11 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/button": "^23.4.1",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/app-layout/package.json
+++ b/packages/app-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/app-layout",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,11 +40,11 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/button": "^23.4.100",
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/avatar-group/package.json
+++ b/packages/avatar-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/avatar-group",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -41,14 +41,14 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/avatar": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/list-box": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/avatar": "^23.4.100",
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/item": "^23.4.100",
+    "@scoped-vaadin/list-box": "^23.4.100",
+    "@scoped-vaadin/overlay": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/avatar-group/package.json
+++ b/packages/avatar-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/avatar-group",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -41,14 +41,14 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/avatar": "^23.4.1",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/item": "^23.4.1",
-    "@scoped-vaadin/list-box": "^23.4.1",
-    "@scoped-vaadin/overlay": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/avatar": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/list-box": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/avatar",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -41,14 +41,14 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/item": "^23.4.1",
-    "@scoped-vaadin/list-box": "^23.4.1",
-    "@scoped-vaadin/overlay": "^23.4.1",
-    "@scoped-vaadin/tooltip": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/list-box": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/tooltip": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/avatar",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -41,14 +41,14 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/list-box": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/tooltip": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/item": "^23.4.100",
+    "@scoped-vaadin/list-box": "^23.4.100",
+    "@scoped-vaadin/overlay": "^23.4.100",
+    "@scoped-vaadin/tooltip": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/button",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,10 +40,10 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/button",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,10 +40,10 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/checkbox-group",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,12 +40,12 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/checkbox": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/checkbox": "^23.4.100",
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/field-base": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/checkbox-group",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,12 +40,12 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/checkbox": "^23.4.1",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/field-base": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/checkbox": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/checkbox",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,11 +40,11 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/field-base": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/checkbox",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,11 +40,11 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/field-base": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/combo-box/package.json
+++ b/packages/combo-box/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/combo-box",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -42,15 +42,15 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/field-base": "^23.4.100",
+    "@scoped-vaadin/input-container": "^23.4.100",
+    "@scoped-vaadin/item": "^23.4.100",
+    "@scoped-vaadin/lit-renderer": "^23.4.100",
+    "@scoped-vaadin/overlay": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/combo-box/package.json
+++ b/packages/combo-box/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/combo-box",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -42,15 +42,15 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/field-base": "^23.4.1",
-    "@scoped-vaadin/input-container": "^23.4.1",
-    "@scoped-vaadin/item": "^23.4.1",
-    "@scoped-vaadin/lit-renderer": "^23.4.1",
-    "@scoped-vaadin/overlay": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/component-base/package.json
+++ b/packages/component-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/component-base",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -36,6 +36,6 @@
     "@vaadin/vaadin-development-mode-detector": "^2.0.0",
     "@vaadin/vaadin-usage-statistics": "^2.1.0",
     "lit": "^2.0.0 || ^3.0.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/component-base/package.json
+++ b/packages/component-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/component-base",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -35,7 +35,7 @@
     "@polymer/polymer": "^3.0.0",
     "@vaadin/vaadin-development-mode-detector": "^2.0.0",
     "@vaadin/vaadin-usage-statistics": "^2.1.0",
-    "lit": "^2.0.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "lit": "^2.0.0 || ^3.0.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/confirm-dialog/package.json
+++ b/packages/confirm-dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/confirm-dialog",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,13 +40,13 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/button": "^23.4.1",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/dialog": "^23.4.1",
-    "@scoped-vaadin/overlay": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/dialog": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/confirm-dialog/package.json
+++ b/packages/confirm-dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/confirm-dialog",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,13 +40,13 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/dialog": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/button": "^23.4.100",
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/dialog": "^23.4.100",
+    "@scoped-vaadin/overlay": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/context-menu/package.json
+++ b/packages/context-menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/context-menu",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -43,14 +43,14 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/list-box": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/item": "^23.4.100",
+    "@scoped-vaadin/list-box": "^23.4.100",
+    "@scoped-vaadin/lit-renderer": "^23.4.100",
+    "@scoped-vaadin/overlay": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/context-menu/package.json
+++ b/packages/context-menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/context-menu",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -43,14 +43,14 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/item": "^23.4.1",
-    "@scoped-vaadin/list-box": "^23.4.1",
-    "@scoped-vaadin/lit-renderer": "^23.4.1",
-    "@scoped-vaadin/overlay": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/list-box": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/custom-field/package.json
+++ b/packages/custom-field/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/custom-field",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -39,11 +39,11 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/field-base": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/custom-field/package.json
+++ b/packages/custom-field/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/custom-field",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -39,11 +39,11 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/field-base": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/date-picker",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,14 +40,14 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.2.0",
-    "@scoped-vaadin/button": "^23.4.1",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/field-base": "^23.4.1",
-    "@scoped-vaadin/input-container": "^23.4.1",
-    "@scoped-vaadin/overlay": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/date-picker",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,14 +40,14 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.2.0",
-    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/button": "^23.4.100",
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/field-base": "^23.4.100",
+    "@scoped-vaadin/input-container": "^23.4.100",
+    "@scoped-vaadin/overlay": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/date-time-picker/package.json
+++ b/packages/date-time-picker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/date-time-picker",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,14 +40,14 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/custom-field": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/date-picker": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/time-picker": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/custom-field": "^23.4.100",
+    "@scoped-vaadin/date-picker": "^23.4.100",
+    "@scoped-vaadin/field-base": "^23.4.100",
+    "@scoped-vaadin/time-picker": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/date-time-picker/package.json
+++ b/packages/date-time-picker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/date-time-picker",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,14 +40,14 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/custom-field": "^23.4.1",
-    "@scoped-vaadin/date-picker": "^23.4.1",
-    "@scoped-vaadin/field-base": "^23.4.1",
-    "@scoped-vaadin/time-picker": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/custom-field": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/date-picker": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/time-picker": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/details/package.json
+++ b/packages/details/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/details",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,11 +40,11 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/field-base": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/details/package.json
+++ b/packages/details/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/details",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,11 +40,11 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/field-base": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/dialog",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -43,12 +43,12 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/lit-renderer": "^23.4.100",
+    "@scoped-vaadin/overlay": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/dialog",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -43,12 +43,12 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/lit-renderer": "^23.4.1",
-    "@scoped-vaadin/overlay": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/email-field/package.json
+++ b/packages/email-field/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/email-field",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -39,11 +39,11 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/text-field": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/text-field": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/email-field/package.json
+++ b/packages/email-field/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/email-field",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -39,11 +39,11 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/text-field": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/text-field": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/field-base/package.json
+++ b/packages/field-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/field-base",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -32,8 +32,8 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/component-base": "^23.4.100",
     "lit": "^2.0.0 || ^3.0.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/field-base/package.json
+++ b/packages/field-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/field-base",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -32,8 +32,8 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "lit": "^2.0.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "lit": "^2.0.0 || ^3.0.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/field-highlighter/package.json
+++ b/packages/field-highlighter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/field-highlighter",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -34,12 +34,12 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/overlay": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
     "lit": "^2.0.0 || ^3.0.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/field-highlighter/package.json
+++ b/packages/field-highlighter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/field-highlighter",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -34,12 +34,12 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/overlay": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "lit": "^2.0.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "lit": "^2.0.0 || ^3.0.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/form-layout/package.json
+++ b/packages/form-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/form-layout",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,10 +40,10 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/form-layout/package.json
+++ b/packages/form-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/form-layout",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,10 +40,10 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/grid",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -50,13 +50,13 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/checkbox": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/text-field": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/checkbox": "^23.4.100",
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/lit-renderer": "^23.4.100",
+    "@scoped-vaadin/text-field": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/grid",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -50,13 +50,13 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/checkbox": "^23.4.1",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/lit-renderer": "^23.4.1",
-    "@scoped-vaadin/text-field": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/checkbox": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/text-field": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/horizontal-layout/package.json
+++ b/packages/horizontal-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/horizontal-layout",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,10 +40,10 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/horizontal-layout/package.json
+++ b/packages/horizontal-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/horizontal-layout",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,10 +40,10 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/icon",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -39,10 +39,10 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "lit": "^2.0.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "lit": "^2.0.0 || ^3.0.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/icon",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -39,10 +39,10 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
     "lit": "^2.0.0 || ^3.0.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/icons",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -39,7 +39,7 @@
     "@polymer/iron-icon": "^3.0.0",
     "@polymer/iron-iconset-svg": "^3.0.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/icon": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/icon": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/icons",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -39,7 +39,7 @@
     "@polymer/iron-icon": "^3.0.0",
     "@polymer/iron-iconset-svg": "^3.0.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/icon": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/icon": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/input-container/package.json
+++ b/packages/input-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/input-container",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -32,10 +32,10 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/input-container/package.json
+++ b/packages/input-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/input-container",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -32,10 +32,10 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/integer-field/package.json
+++ b/packages/integer-field/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/integer-field",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -39,10 +39,10 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/number-field": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/number-field": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/integer-field/package.json
+++ b/packages/integer-field/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/integer-field",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -39,10 +39,10 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/number-field": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/number-field": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/item/package.json
+++ b/packages/item/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/item",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -41,10 +41,10 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/item/package.json
+++ b/packages/item/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/item",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -41,10 +41,10 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/list-box/package.json
+++ b/packages/list-box/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/list-box",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,12 +40,12 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-list-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/item": "^23.4.100",
+    "@scoped-vaadin/vaadin-list-mixin": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/list-box/package.json
+++ b/packages/list-box/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/list-box",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,12 +40,12 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/item": "^23.4.1",
-    "@scoped-vaadin/vaadin-list-mixin": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-list-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/lit-renderer/package.json
+++ b/packages/lit-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/lit-renderer",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -31,6 +31,6 @@
   ],
   "dependencies": {
     "lit": "^2.0.0 || ^3.0.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/lit-renderer/package.json
+++ b/packages/lit-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/lit-renderer",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -30,7 +30,7 @@
     "lit"
   ],
   "dependencies": {
-    "lit": "^2.0.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "lit": "^2.0.0 || ^3.0.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/login",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -41,14 +41,14 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/password-field": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/text-field": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/button": "^23.4.100",
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/overlay": "^23.4.100",
+    "@scoped-vaadin/password-field": "^23.4.100",
+    "@scoped-vaadin/text-field": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/login",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -41,14 +41,14 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/button": "^23.4.1",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/overlay": "^23.4.1",
-    "@scoped-vaadin/password-field": "^23.4.1",
-    "@scoped-vaadin/text-field": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/password-field": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/text-field": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/menu-bar/package.json
+++ b/packages/menu-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/menu-bar",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -41,12 +41,12 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/button": "^23.4.1",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/context-menu": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/context-menu": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/menu-bar/package.json
+++ b/packages/menu-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/menu-bar",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -41,12 +41,12 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/context-menu": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/button": "^23.4.100",
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/context-menu": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/message-input/package.json
+++ b/packages/message-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/message-input",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,12 +40,12 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/text-area": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/button": "^23.4.100",
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/text-area": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/message-input/package.json
+++ b/packages/message-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/message-input",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,12 +40,12 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/button": "^23.4.1",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/text-area": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/text-area": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/message-list/package.json
+++ b/packages/message-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/message-list",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -42,11 +42,11 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/avatar": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/avatar": "^23.4.100",
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/message-list/package.json
+++ b/packages/message-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/message-list",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -42,11 +42,11 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/avatar": "^23.4.1",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/avatar": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/multi-select-combo-box/package.json
+++ b/packages/multi-select-combo-box/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/multi-select-combo-box",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -41,14 +41,14 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/combo-box": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/combo-box": "^23.4.100",
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/field-base": "^23.4.100",
+    "@scoped-vaadin/input-container": "^23.4.100",
+    "@scoped-vaadin/lit-renderer": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/multi-select-combo-box/package.json
+++ b/packages/multi-select-combo-box/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/multi-select-combo-box",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -41,14 +41,14 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/combo-box": "^23.4.1",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/field-base": "^23.4.1",
-    "@scoped-vaadin/input-container": "^23.4.1",
-    "@scoped-vaadin/lit-renderer": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/combo-box": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/notification",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -42,12 +42,12 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/lit-renderer": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "lit": "^2.0.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "lit": "^2.0.0 || ^3.0.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/notification",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -42,12 +42,12 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/lit-renderer": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
     "lit": "^2.0.0 || ^3.0.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/number-field",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -39,12 +39,12 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/field-base": "^23.4.100",
+    "@scoped-vaadin/input-container": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/number-field",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -39,12 +39,12 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/field-base": "^23.4.1",
-    "@scoped-vaadin/input-container": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/overlay",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -36,10 +36,10 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/overlay",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -36,10 +36,10 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/password-field/package.json
+++ b/packages/password-field/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/password-field",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -39,12 +39,12 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/text-field": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/button": "^23.4.100",
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/text-field": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/password-field/package.json
+++ b/packages/password-field/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/password-field",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -39,12 +39,12 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/button": "^23.4.1",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/text-field": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/text-field": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/polymer-legacy-adapter/package.json
+++ b/packages/polymer-legacy-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/polymer-legacy-adapter",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -32,8 +32,8 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
     "lit": "^2.0.0 || ^3.0.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/polymer-legacy-adapter/package.json
+++ b/packages/polymer-legacy-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/polymer-legacy-adapter",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -32,8 +32,8 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "lit": "^2.0.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "lit": "^2.0.0 || ^3.0.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/progress-bar",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -42,10 +42,10 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/progress-bar",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -42,10 +42,10 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/radio-group",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -42,11 +42,11 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/field-base": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/radio-group",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -42,11 +42,11 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/field-base": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/scroller/package.json
+++ b/packages/scroller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/scroller",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,10 +40,10 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/scroller/package.json
+++ b/packages/scroller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/scroller",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,10 +40,10 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/select",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -42,18 +42,18 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.2.0",
-    "@scoped-vaadin/button": "^23.4.1",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/field-base": "^23.4.1",
-    "@scoped-vaadin/input-container": "^23.4.1",
-    "@scoped-vaadin/item": "^23.4.1",
-    "@scoped-vaadin/list-box": "^23.4.1",
-    "@scoped-vaadin/lit-renderer": "^23.4.1",
-    "@scoped-vaadin/overlay": "^23.4.1",
-    "@scoped-vaadin/vaadin-list-mixin": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/list-box": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-list-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/select",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -42,18 +42,18 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.2.0",
-    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/list-box": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-list-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/button": "^23.4.100",
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/field-base": "^23.4.100",
+    "@scoped-vaadin/input-container": "^23.4.100",
+    "@scoped-vaadin/item": "^23.4.100",
+    "@scoped-vaadin/list-box": "^23.4.100",
+    "@scoped-vaadin/lit-renderer": "^23.4.100",
+    "@scoped-vaadin/overlay": "^23.4.100",
+    "@scoped-vaadin/vaadin-list-mixin": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/split-layout/package.json
+++ b/packages/split-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/split-layout",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,10 +40,10 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/split-layout/package.json
+++ b/packages/split-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/split-layout",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,10 +40,10 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/tabs",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,12 +40,12 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-list-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/item": "^23.4.100",
+    "@scoped-vaadin/vaadin-list-mixin": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/tabs",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,12 +40,12 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/item": "^23.4.1",
-    "@scoped-vaadin/vaadin-list-mixin": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/item": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-list-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/tabsheet/package.json
+++ b/packages/tabsheet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/tabsheet",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,13 +40,13 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/scroller": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/tabs": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/field-base": "^23.4.100",
+    "@scoped-vaadin/scroller": "^23.4.100",
+    "@scoped-vaadin/tabs": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/tabsheet/package.json
+++ b/packages/tabsheet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/tabsheet",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,13 +40,13 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/field-base": "^23.4.1",
-    "@scoped-vaadin/scroller": "^23.4.1",
-    "@scoped-vaadin/tabs": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/scroller": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/tabs": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/text-area",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -39,12 +39,12 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/field-base": "^23.4.1",
-    "@scoped-vaadin/input-container": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/text-area",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -39,12 +39,12 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/field-base": "^23.4.100",
+    "@scoped-vaadin/input-container": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/text-field/package.json
+++ b/packages/text-field/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/text-field",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -39,12 +39,12 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/field-base": "^23.4.1",
-    "@scoped-vaadin/input-container": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/text-field/package.json
+++ b/packages/text-field/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/text-field",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -39,12 +39,12 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/field-base": "^23.4.100",
+    "@scoped-vaadin/input-container": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/time-picker/package.json
+++ b/packages/time-picker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/time-picker",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,13 +40,13 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/combo-box": "^23.4.1",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/field-base": "^23.4.1",
-    "@scoped-vaadin/input-container": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/combo-box": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/time-picker/package.json
+++ b/packages/time-picker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/time-picker",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,13 +40,13 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/combo-box": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/field-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/input-container": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/combo-box": "^23.4.100",
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/field-base": "^23.4.100",
+    "@scoped-vaadin/input-container": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/tooltip",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -39,11 +39,11 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/overlay": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/tooltip",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -39,11 +39,11 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/overlay": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/overlay": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/upload",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,12 +40,12 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/button": "^23.4.1",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/progress-bar": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/progress-bar": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/upload",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,12 +40,12 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/button": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/progress-bar": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/button": "^23.4.100",
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/progress-bar": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/vaadin-list-mixin/package.json
+++ b/packages/vaadin-list-mixin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/vaadin-list-mixin",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -33,7 +33,7 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/vaadin-list-mixin/package.json
+++ b/packages/vaadin-list-mixin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/vaadin-list-mixin",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -33,7 +33,7 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/vaadin-lumo-styles/package.json
+++ b/packages/vaadin-lumo-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/vaadin-lumo-styles",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -43,8 +43,8 @@
     "@polymer/iron-icon": "^3.0.0",
     "@polymer/iron-iconset-svg": "^3.0.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/icon": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/icon": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/vaadin-lumo-styles/package.json
+++ b/packages/vaadin-lumo-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/vaadin-lumo-styles",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -43,8 +43,8 @@
     "@polymer/iron-icon": "^3.0.0",
     "@polymer/iron-iconset-svg": "^3.0.0",
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/icon": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/icon": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/vaadin-material-styles/package.json
+++ b/packages/vaadin-material-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/vaadin-material-styles",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -39,7 +39,7 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/vaadin-material-styles/package.json
+++ b/packages/vaadin-material-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/vaadin-material-styles",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -39,7 +39,7 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/vaadin-themable-mixin/package.json
+++ b/packages/vaadin-themable-mixin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/vaadin-themable-mixin",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -32,7 +32,7 @@
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "lit": "^2.0.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "lit": "^2.0.0 || ^3.0.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/vaadin-themable-mixin/package.json
+++ b/packages/vaadin-themable-mixin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/vaadin-themable-mixin",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -33,6 +33,6 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "lit": "^2.0.0 || ^3.0.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/vertical-layout/package.json
+++ b/packages/vertical-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/vertical-layout",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,10 +40,10 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/packages/vertical-layout/package.json
+++ b/packages/vertical-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/vertical-layout",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -40,10 +40,10 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/virtual-list/package.json
+++ b/packages/virtual-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/virtual-list",
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -42,11 +42,11 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1",
-    "@scoped-vaadin/lit-renderer": "^23.4.1",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1"
+    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
   }
 }

--- a/packages/virtual-list/package.json
+++ b/packages/virtual-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoped-vaadin/virtual-list",
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/robrez/scoped-vaadin.git",
@@ -42,11 +42,11 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@scoped-vaadin/component-base": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/lit-renderer": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-material-styles": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.1-litcompat.0",
-    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.1-litcompat.0"
+    "@scoped-vaadin/component-base": "^23.4.100",
+    "@scoped-vaadin/lit-renderer": "^23.4.100",
+    "@scoped-vaadin/vaadin-lumo-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-material-styles": "^23.4.100",
+    "@scoped-vaadin/vaadin-themable-mixin": "^23.4.100",
+    "@scoped-vaadin/internal-custom-elements-registry": "^23.4.100"
   }
 }

--- a/scripts/meta/version.js
+++ b/scripts/meta/version.js
@@ -1,5 +1,5 @@
 export const versionMeta = {
-  version: "23.4.1-litcompat.0",
+  version: "23.4.100",
   selector: "^",
   repository: {
     type: "git",

--- a/scripts/meta/version.js
+++ b/scripts/meta/version.js
@@ -1,5 +1,5 @@
 export const versionMeta = {
-  version: "23.4.1",
+  version: "23.4.1-litcompat.0",
   selector: "^",
   repository: {
     type: "git",

--- a/scripts/transform/transformPackageJson.js
+++ b/scripts/transform/transformPackageJson.js
@@ -30,6 +30,10 @@ export function transformPackageJson(content, filePath) {
     newDependencies[newDepName] = newDepVersion;
   });
 
+  if (newDependencies["lit"] && newDependencies["lit"] === "^2.0.0") {
+    newDependencies["lit"] = "^2.0.0 || ^3.0.0";
+  }
+
   const additionalDependencies = {
     "@scoped-vaadin/internal-custom-elements-registry": versionMetaSelector,
   };

--- a/vendor-packages/internal-custom-elements-registry/package.json
+++ b/vendor-packages/internal-custom-elements-registry/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "name": "@scoped-vaadin/internal-custom-elements-registry",
   "publishConfig": {
     "access": "public"

--- a/vendor-packages/internal-custom-elements-registry/package.json
+++ b/vendor-packages/internal-custom-elements-registry/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "name": "@scoped-vaadin/internal-custom-elements-registry",
   "publishConfig": {
     "access": "public"

--- a/vendor-packages/vaadin-all/package.json
+++ b/vendor-packages/vaadin-all/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "23.4.1-litcompat.0",
+  "version": "23.4.100",
   "name": "@scoped-vaadin/vaadin-all",
   "private": true,
   "description": "",

--- a/vendor-packages/vaadin-all/package.json
+++ b/vendor-packages/vaadin-all/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "23.4.1",
+  "version": "23.4.1-litcompat.0",
   "name": "@scoped-vaadin/vaadin-all",
   "private": true,
   "description": "",


### PR DESCRIPTION
Updates all packages with a "lit" dependency to use `^2.0.0 || ^3.0.0` instead of just `^2.0.0`. This is an internal choice not found in official vaadin components. The purpose is:

- allow lit renderer helpers to be compatible with 2.x OR 3.x
- allow deduplication of lit dependencies